### PR TITLE
docs(repo): remove internal doc references

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ KkapsCa-project-kickstart/
         └── assets/
 ```
 
-### Documentación interna
-
-- `docs/internal/` contiene briefs y meta-documentación interna; no es contexto operativo de skills.
-
 Se divide en dos grupos:
 
 ### 1. Skills de inicio de proyecto

--- a/docs/sdd-proposal-workflow-hardening.md
+++ b/docs/sdd-proposal-workflow-hardening.md
@@ -14,7 +14,7 @@ Harden existing skills and define a standard for future skills to ensure high-qu
 ## Approach
 1. **Spec**: Draft `docs/skill-hardening-guide.md`.
 2. **Refactor**: Update `dev-skills/repo-bootstrap/SKILL.md` with the new decision table.
-3. **Verify**: Ensure the proposed changes align with the "weak-agent friendly" design philosophy defined in `docs/internal/claude-review-brief.md`.
+3. **Verify**: Ensure the proposed changes align with the repository's weak-agent friendly philosophy defined in `README.md`.
 
 ## Rollback / Risks
 - **Rollback**: Simple revert of commits.


### PR DESCRIPTION
Closes #13

## PR Type
- [x] Documentation only

## Summary
- Removed the last public references to the deleted internal review brief.
- Kept the repository focused on operational/public docs only.

## Changes Table
| File | Change |
|------|--------|
| `README.md` | Removed the internal-docs note. |
| `docs/sdd-proposal-workflow-hardening.md` | Repointed the reference away from the deleted brief. |

## Test Plan
- [x] Manual review of the docs changes
- [x] Verified no remaining references to the deleted brief

## Contributor Checklist
- [x] Linked an approved issue (`status:approved`)
- [x] Added exactly one `type:*` label
- [x] Docs updated if behavior changed
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers