### PR TITLE
chore(release-governance): harden release governance

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -83,3 +83,40 @@ jobs:
             }
 
             core.info(`PR type label detected: ${typeLabels[0]}`);
+
+  check-conventional-commits:
+    name: Validate Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 50,
+            });
+
+            const conventionalPattern = /^(feat|fix|docs|style|refactor|perf|test|ci|build|chore|revert)(\([^)]+\))?!?: .{1,}/;
+            const invalidCommits = [];
+
+            for (const commit of commits) {
+              const message = commit.commit.message.split('\n')[0];
+              if (!conventionalPattern.test(message)) {
+                invalidCommits.push(message);
+              }
+            }
+
+            if (invalidCommits.length > 0) {
+              core.setFailed(
+                `The following commits do not follow Conventional Commits format:\n` +
+                invalidCommits.map(c => `- ${c}`).join('\n') +
+                `\n\nRequired format: <type>(<scope>)?: <description>\n` +
+                `Types: feat, fix, docs, style, refactor, perf, test, ci, build, chore, revert`
+              );
+              return;
+            }
+
+            core.info(`All ${commits.length} commit(s) follow Conventional Commits format.`);

--- a/README.md
+++ b/README.md
@@ -189,6 +189,34 @@ Este repositorio usa **release-please** para manejar versionado semántico, chan
 3. GitHub crea o actualiza un **Release PR** con versión y changelog.
 4. Al mergear ese Release PR, se publica el tag y el GitHub Release.
 
+### Tipos de commits y su impacto en versiones
+
+| Tipo de commit | ¿Dispara release? | Tipo de cambio |
+|----------------|-------------------|---------------|
+| `feat:` | ✅ Sí | minor (0.1.0 → 0.2.0) |
+| `fix:` | ✅ Sí | patch (0.0.1 → 0.0.2) |
+| `feat:` + `!` o `BREAKING CHANGE:` | ✅ Sí | major (0.1.0 → 1.0.0) |
+| `fix:` + `!` o `BREAKING CHANGE:` | ✅ Sí | major (0.1.0 → 1.0.0) |
+| `docs:` | ❌ No | — |
+| `chore:` | ❌ No | — |
+| `refactor:` | ❌ No | — |
+| `test:` | ❌ No | — |
+| `ci:` | ❌ No | — |
+| `build:` | ❌ No | — |
+| `style:` | ❌ No | — |
+| `perf:` | ❌ Tal vez* | — |
+| `[skip release]` | ❌ No | fuerza skip |
+
+> **Nota**: Commits de `perf:` pueden disparar release depending configuración, pero típicamente no lo hacen.
+
+### Release-please跳过
+
+Para evitar que un commit dispare release, añade `[skip release]` o `[no-release]` en el mensaje:
+
+```bash
+git commit -m "chore: update deps [skip release]"
+```
+
 ### Reglas de commits
 
 - `feat:` → minor
@@ -197,6 +225,36 @@ Este repositorio usa **release-please** para manejar versionado semántico, chan
 - `docs:`, `chore:`, `refactor:`, `test:`, `ci:` → normalmente no disparan release funcional
 
 La meta es NO versionar manualmente a mano ni mantener changelogs a puro copy-paste.
+
+---
+
+## Protección de ramas
+
+### main branch protection
+
+Este repositorio **requiere** que la rama `main` tenga protección habilitada en GitHub:
+
+1. Ve a **Settings → Branches → Branch protection rules**
+2. Crea una regla para `main`
+3. Configura:
+   - ✅ **Require approvals** (al menos 1)
+   - ✅ **Require status checks to pass** antes de merge
+   - ✅ **Require conversation resolution** antes de merge
+   - ❌ **Allow force pushes** → NO permitido
+   - ❌ **Allow deletions** → NO permitido
+
+### Flujo de contribución
+
+1. **No seas ese wey que hace push directo a main** 😤
+2. Todo cambio entra por **Pull Request**
+3. El PR debe tener:
+   - Labels `type:*` y `status:approved`
+   - Referencia a issue (Closes #N)
+   - Commits en formato Conventional Commits
+   - Todos los status checks pasando
+4. **Auto-merge** solo después de validación exitosa
+
+La meta es mantener historial limpio, cambios trazables y releases automatizados sin intervención manual.
 
 ---
 

--- a/docs/branch-protection-settings.md
+++ b/docs/branch-protection-settings.md
@@ -1,0 +1,46 @@
+# Branch Protection Settings — Requerido en GitHub
+
+> Este archivo documenta la configuración necesaria de branch protection en GitHub. Los cambios deben aplicarse **manualmente en la interfaz de GitHub**; no pueden configurarse mediante archivos en el repositorio.
+
+## Configuración requerida para `main`
+
+### En GitHub: Settings → Branches → Branch protection rules
+
+| Configuración | Valor |
+|-------------|-------|
+| Branch name pattern | `main` |
+| ✅ Require pull request reviews before merging | 1 approve required |
+| ✅ Require status checks to pass before merging | (selecciona los checks de PR validation) |
+| ✅ Require conversation resolution | enabled |
+| ✅ Require branches to be up to date before merging | enabled |
+| ❌ Allow force pushes | **DESACTIVADO** |
+| ❌ Allow deletions | **DESACTIVADO** |
+| ✅ Include administrators | enabled |
+
+## Por qué esto importa
+
+- **Sin protección en main**: anyone puede hacer push directo → se pierde trazabilidad
+- **Sin require approvals**: se pueden mergear cambios sin review
+- **Sin status checks**: cambios que no pasan validaciones pueden llegar a main
+
+## Workflow esperado
+
+```
+1. Crear branch feature/fix-descriptive-name
+2. Trabajar con commits Conventional Commits
+3. Abrir PR con labels type:*, status:approved
+4. esperar a que pase PR validation (incluye conventional commits check)
+5. una vez approvals + checks verdes → merge
+6. release-please detecta y crea Release PR
+7. al mergear Release PR → tag + release
+```
+
+##記住
+
+- Este documento es **solo lectura/reference**
+- La configuración real se hace en GitHub
+- Repo admins deben aplicar estos settings manualmente
+
+---
+
+Para dudas sobre el flujo de contribución, ver README.md sección "Protección de ramas".


### PR DESCRIPTION
Closes #18

## Summary
- Harden release governance for main branch protection and PR validation.
- Document which commits do and do not trigger release-please.
- Add a manual GitHub settings guide for branch protection.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/pr-validation.yml` | Add Conventional Commits validation for PR commits |
| `README.md` | Clarify release trigger semantics and branch protection expectations |
| `docs/branch-protection-settings.md` | Document required GitHub-side branch protection settings |

## Test Plan
- [x] Verified PR body links an approved issue
- [x] Verified the new Conventional Commits validation job is present
- [x] Verified branch protection settings guidance is documented

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Conventional commit format
- [x] Docs updated
