### PR TITLE
feat(skills): align project pipeline with PMBOK lite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ pubspec.lock
 
 # Local AI workflow artifacts
 .atl/
+
+# Internal planning / research artifacts (do not publish)
+docs/resumen flujo de trabajo.txt
+docs/Flujo_de_Procesos_PMBOK_8.md
+docs/sdd-*.md
+docs/*archive*.json
+sdd-*.md

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ KkapsCa-project-kickstart/
 │   └── SKILL.md
 ├── product-discovery/
 │   └── SKILL.md
+├── project-init/
+│   ├── SKILL.md
+│   └── README.md
 ├── tech-feasibility/
 │   └── SKILL.md
 └── dev-skills/
@@ -78,6 +81,7 @@ Sirven para aterrizar una idea antes de construir.
 
 - **brainstorm** → convierte una idea vaga en un Product Brief.
 - **product-discovery** → valida mercado, usuario, competencia y negocio.
+- **project-init** → cierra la brecha entre discovery y factibilidad (opcional por bypass).
 - **tech-feasibility** → evalúa stack, riesgos, arquitectura y esfuerzo.
 
 ### 2. Skills de desarrollo
@@ -96,8 +100,19 @@ Estas skills no se distribuyen en este repo público. Si existe una convención 
 El flujo ideal para un proyecto nuevo es este:
 
 ```text
+Idea → brainstorm → product-discovery → project-init → tech-feasibility → repo-bootstrap → Desarrollo
+```
+
+**Ruta ligera (bypass de project-init)**:
+```text
 Idea → brainstorm → product-discovery → tech-feasibility → repo-bootstrap → Desarrollo
 ```
+
+**Condiciones para bypass de project-init**:
+- Proyecto personal con alcance muy pequeño (1-2 features)
+- El usuario es el único interesado y decisor
+- No hay restricciones regulatorias ni organizacionales
+- tech-feasibility puede funcionar con Discovery Report directo
 
 Pero este repositorio **no es dogmático**.
 
@@ -107,10 +122,11 @@ Si ya tienes trabajo previo real, puedes entrar más adelante en el pipeline.
 
 - Si solo tienes una idea vaga → empieza en **brainstorm**.
 - Si ya tienes claro problema, usuario y MVP → puedes entrar en **product-discovery**.
-- Si ya validaste el mercado y solo necesitas aterrizar la ejecución técnica → entra en **tech-feasibility**.
+- Si ya tienes Discovery Report completo y quieres cerrar brecha → usa **project-init** (recomendado).
+- Si ya tienes claridad funcional y solo falta tech → entra en **tech-feasibility**.
 - Si ya tienes claridad funcional y técnica → usa una **dev-skill**.
 
-La regla no es “seguir pasos porque sí”.
+La regla no es "seguir pasos porque sí".
 La regla es **no saltarte el pensamiento que todavía no has hecho**.
 
 ---
@@ -133,9 +149,10 @@ Este repo puede servirle a:
 
 1. Usa `brainstorm`
 2. Continúa con `product-discovery`
-3. Sigue con `tech-feasibility`
-4. Aplica `dev-skills/repo-bootstrap`
-5. Pasa a la skill de desarrollo adecuada
+3. Sigue con `project-init` (o sáltala solo si aplica el bypass)
+4. Continúa con `tech-feasibility`
+5. Aplica `dev-skills/repo-bootstrap`
+6. Pasa a la skill de desarrollo adecuada
 
 ### Si ya estás en etapa de implementación
 
@@ -158,9 +175,10 @@ Si el repo aún no tiene estándares operativos claros, aplica primero `repo-boo
 
 Skills disponibles hoy:
 
-- `brainstorm`
-- `product-discovery`
-- `tech-feasibility`
+- `brainstorm` (Paso 1)
+- `product-discovery` (Paso 2)
+- `project-init` (Paso 3 — transición, opcional para proyectos pequeños)
+- `tech-feasibility` (Paso 4)
 - `flutter-personal-standards`
 - `repo-bootstrap`
 

--- a/brainstorm/SKILL.md
+++ b/brainstorm/SKILL.md
@@ -12,14 +12,15 @@ description: >
 license: Apache-2.0
 metadata:
   author: KkapsCa
-  version: "3.0"
+  version: "4.0"
   pipeline: "project-kickstart/01"
   next: "product-discovery"
+  prev: ""
 ---
 
 # Brainstorm — Step 1
 
-> **Pipeline recomendado:** `brainstorm` → `product-discovery` → `tech-feasibility`
+> **Pipeline recomendado:** `brainstorm` → `product-discovery` → `project-init` → `tech-feasibility`
 > **Input:** idea vaga, intuición o problema mal definido
 > **Output:** Product Brief
 
@@ -29,11 +30,11 @@ metadata:
 
 Usa esta skill cuando el usuario diga cosas como:
 
-- “tengo una idea”,
-- “quiero hacer una app”,
-- “no sé por dónde empezar”,
-- “ayúdame a aterrizar esto”,
-- “quiero definir mejor mi producto”.
+- "tengo una idea",
+- "quiero hacer una app",
+- "no sé por dónde empezar",
+- "ayúdame a aterrizar esto",
+- "quiero definir mejor mi producto".
 
 ## When NOT to Use
 
@@ -58,14 +59,14 @@ Si alguna casilla falla, no uses esta skill; pasa a la skill correcta.
 Brainstorm no es lanzar ideas al aire.
 Es convertir intuición en una hipótesis de producto que se pueda analizar después.
 
-### Orden correcto
+### Orden correcto (PMBOK 8)
 
-1. **Problema**
-2. **Usuario**
-3. **Propuesta de valor**
-4. **MVP**
-5. **Diferenciadores**
-6. **Preguntas abiertas**
+1. **Problema** — Identificar el dolor real
+2. **Usuario** — Identificar el usuario principal
+3. **Propuesta de valor** — Proponer solución
+4. **MVP** — Definir lo mínimo necesario
+5. **Diferenciadores** — Elegir 1-2 ventajas clave
+6. **Preguntas abiertas** — Qué dudas quedan
 
 La tecnología va al final, no al principio.
 
@@ -81,12 +82,12 @@ Avanza a Fase 2 solo cuando exista una explicación de 30 segundos y haya al men
 
 ### Pregunta de arranque
 
-> “Explícame tu idea como si me la contaras en 30 segundos.”
+> "Explícame tu idea como si me la contaras en 30 segundos."
 
 ### Qué observar
 
 - ¿habla de un problema o solo de una solución?,
-- ¿hay un usuario concreto o “todo el mundo”?,
+- ¿hay un usuario concreto o "todo el mundo"?,
 - ¿menciona referentes?,
 - ¿suena a dolor real o a ocurrencia simpática?
 
@@ -116,9 +117,9 @@ No avances a Fase 3 si faltan problema, solución actual o gap.
 
 ---
 
-## Fase 3 — Usuario principal
+## Fase 3 — Usuario principal + Interesados (PMBOK 8)
 
-“Para todos” no sirve.
+"Para todos" no sirve.
 
 ### Regla para avanzar
 
@@ -133,7 +134,13 @@ Define un usuario primario con estas preguntas:
 
 ### Pregunta clave
 
-> “¿Quién es la persona que más necesita esto y que más se beneficiaría si existiera mañana?”
+> "¿Quién es la persona que más necesita esto y que más se beneficiaría si existiera mañana?"
+
+**PMBOK 8 - Interesados**: amplía a:
+- Usuario principal (quien sufre)
+- Patrocinador/decisor (quién aprueba/invierte)
+- Equipo (quién construirá)
+- Interesados secundarios/regulatorios (según aplique)
 
 ---
 
@@ -154,7 +161,7 @@ Avanza a Fase 5 solo cuando la frase de valor sea clara y específica.
 
 ---
 
-## Fase 5 — MVP
+## Fase 5 — MVP (y alcance inicial)
 
 Separa lo esencial de lo decorativo.
 
@@ -206,14 +213,16 @@ Si no puedes elegir máximo 2 diferenciadores claros, no cierres el brief todav�
 
 ---
 
-## Output Final — Product Brief
+## Output Final — Product Brief v4.0
 
 Solo genera este bloque cuando ya pasaste por todas las reglas de avance anteriores.
 
 ```markdown
 # [Nombre Tentativo] — Product Brief
-**Generado por:** brainstorm skill v3.0
+**Generado por:** brainstorm skill v4.0
 **Fecha:** [fecha]
+**Contexto org:** [personal / negocio / organización]
+**Interesados:** [lista principal]
 
 ## 1. Problema
 [descripción concreta del dolor]
@@ -235,20 +244,32 @@ Solo genera este bloque cuando ya pasaste por todas las reglas de avance anterio
 
 ## 6. MVP
 ### Must Have
-- [feature]
+- [feature 1]
+- [feature 2]
 
 ### Fuera del MVP
-- [feature]
+- [feature 3]
 
-## 7. Diferenciadores
+## 7. Valor esperado
+- Para el usuario: [qué gana]
+- Para el negocio: [qué valor genera]
+- Señal de éxito: [métrica o señal]
+
+## 8. Diferenciadores
 - [diferenciador 1]
 - [diferenciador 2]
 
-## 8. Dudas abiertas
-- [pregunta]
-- [supuesto por validar]
+## 9. Interesados ampliados (PMBOK 8)
+- Principal: [descripción]
+- Patrocinador: [descripción - si aplica]
+- Equipo: [descripción]
+- Regulatorios: [descripción - si aplica]
 
-## 9. Siguiente paso
+## 10. Dudas abiertas
+- [pregunta 1]
+- [supuesto por validar 1]
+
+## 11. Siguiente paso
 - Pasar a product-discovery
 ```
 
@@ -258,8 +279,10 @@ Solo genera este bloque cuando ya pasaste por todas las reglas de avance anterio
 
 Esta fase está suficientemente completa cuando ya existe:
 
-- un problema claro,
-- un usuario principal identificable,
-- una propuesta de valor entendible,
-- un MVP recortado,
-- y suficientes insumos para pasar a discovery sin improvisar todo.
+- ✅ un problema claro,
+- ✅ un usuario principal identificable,
+- ✅ una propuesta de valor entendible,
+- ✅ un MVP recortado,
+- ✅ valor esperado claro,
+- ✅ interesados ampliados según PMBOK 8,
+- ✅ suficientes insumos para pasar a discovery sin improvisar.

--- a/product-discovery/SKILL.md
+++ b/product-discovery/SKILL.md
@@ -13,15 +13,15 @@ description: >
 license: Apache-2.0
 metadata:
   author: KkapsCa
-  version: "2.0"
+  version: "3.0"
   pipeline: "project-kickstart/02"
   prev: "brainstorm"
-  next: "tech-feasibility"
+  next: "project-init"
 ---
 
 # Product Discovery — Step 2
 
-> **Pipeline recomendado:** `brainstorm` → `product-discovery` → `tech-feasibility`
+> **Pipeline recomendado:** `brainstorm` → `product-discovery` → `project-init` → `tech-feasibility`
 > **Input ideal:** Product Brief o idea ya suficientemente definida
 > **Output:** Discovery Report
 
@@ -74,7 +74,7 @@ No todos los proyectos requieren el mismo nivel de discovery.
 Clasifica primero:
 
 - **Aprendizaje** → prioridad: entender problema, usuario y utilidad.
-- **Side project / microproducto** → prioridad: validar interés rápido.
+- **Side project / microproducto** → prioridad: validar interés rápido (lanzar `project-init` tras discovery).
 - **Producto serio / negocio** → prioridad: mercado, monetización y viabilidad.
 - **Herramienta interna** → prioridad: utilidad clara y ahorro de tiempo/costo.
 
@@ -82,16 +82,16 @@ Clasifica primero:
 
 ## Dos modos de trabajo
 
-| Condición | Modo |
-|---|---|
-| Quieren lanzar un producto serio | Modo A — Discovery completo |
-| Planean monetizar | Modo A — Discovery completo |
-| Hay inversión importante de tiempo o dinero | Modo A — Discovery completo |
-| Necesitan justificar la idea ante otras personas | Modo A — Discovery completo |
-| Es side project | Modo B — Discovery ligero |
-| Es herramienta personal o interna | Modo B — Discovery ligero |
-| Están aprendiendo | Modo B — Discovery ligero |
-| Quieren validar interés rápido | Modo B — Discovery ligero |
+| Condición | Modo | Pipeline resultante |
+|---|---|---|
+| Quieren lanzar un producto serio | Modo A — Discovery completo | `brainstorm → product-discovery → project-init → tech-feasibility` |
+| Planean monetizar | Modo A — Discovery completo | `brainstorm → product-discovery → project-init → tech-feasibility` |
+| Hay inversión importante de tiempo o dinero | Modo A — Discovery completo | `brainstorm → product-discovery → project-init → tech-feasibility` |
+| Necesitan justificar la idea ante otras personas | Modo A — Discovery completo | `brainstorm → product-discovery → project-init → tech-feasibility` |
+| Es side project | Modo B — Discovery ligero | `brainstorm → product-discovery → project-init (opcional) → tech-feasibility` |
+| Es herramienta personal o interna | Modo B — Discovery ligero | `brainstorm → product-discovery → project-init (opcional) → tech-feasibility` |
+| Están aprendiendo | Modo B — Discovery ligero | `brainstorm → product-discovery → project-init (opcional) → tech-feasibility` |
+| Quieren validar interés rápido | Modo B — Discovery ligero | `brainstorm → product-discovery → project-init (opcional) → tech-feasibility` |
 
 ### Modo A — Discovery completo
 
@@ -100,6 +100,17 @@ Si ninguna fila aplica claramente, pregunta al usuario antes de continuar.
 ### Modo B — Discovery ligero
 
 Si ninguna fila aplica claramente, pregunta al usuario antes de continuar.
+
+### Transición a `project-init`
+
+**Desde `product-discovery`**: El Discovery Report debe incluir:
+- Usuario principal identificado
+- Problema validado
+- Hipótesis de riesgos
+- Enfoque sugerido (enlace a la señal de Paso 0)
+- Estos son los insumos para `project-init`
+
+**Nota**: `project-init` recibe el output de `product-discovery` y produce el Project Framing Doc que `tech-feasibility` consume.
 
 ---
 
@@ -126,7 +137,7 @@ Si el proyecto no requiere análisis pesado, responde estas 5 cosas:
 
 ### Salida del modo ligero
 
-Si estas 5 respuestas están claras, puedes pasar a `tech-feasibility` sin hacer discovery completo.
+Si estas 5 respuestas están claras, puedes pasar a `project-init` (opcional) → `tech-feasibility` sin hacer discovery completo.
 
 ---
 
@@ -342,7 +353,7 @@ Esta skill está suficientemente bien resuelta cuando ya existe:
 - [duda 2]
 
 ## 10. Siguiente paso
-- pasar a tech-feasibility
+- Pasar a project-init (o tech-feasibility por bypass)
 ```
 
 ---

--- a/project-init/README.md
+++ b/project-init/README.md
@@ -1,0 +1,51 @@
+# Project Init — Skill de Transición
+
+## Qué hace
+
+Esta skill cierra la brecha entre `product-discovery` y `tech-feasibility`, transformando los hallazgos de discovery en un plan ejecutable para desarrollo técnico.
+
+## Output Principal
+
+- **Project Framing Doc** (nombre canónico)
+- **Project Charter** (alias temporal, nota secundaria)
+
+## Documentación Completa
+
+Ver [SKILL.md](SKILL.md) para la especificación detallada de la fase, procesos, handoffs y casos de uso.
+
+## Uso Rápido
+
+### Pipeline completo (4 pasos)
+
+```
+brainstorm → product-discovery → project-init → tech-feasibility
+```
+
+### Ruta ligera (bypass de project-init, 3 pasos)
+
+```
+brainstorm → product-discovery → tech-feasibility
+```
+
+**Condiciones para bypass**:
+- Proyecto personal con alcance muy pequeño (1-2 features)
+- El usuario es el único interesado y decisor
+- No hay restricciones regulatorias ni organizacionales
+- tech-feasibility puede funcionar con Discovery Report directo
+
+## Archivos de Referencia
+
+- [SKILL.md](SKILL.md) — Especificación completa de la skill
+- [../docs/sdd-pmbok8-lite-alignment-spec.md](../docs/sdd-pmbok8-lite-alignment-spec.md) — Cambio completo (pmbok8-lite-alignment)
+
+## Output Esperado
+
+- **Project Framing Doc** (Project Charter como alias): Enfoque, fases, alcance inicial y gobernanza mínima
+- **Próximos pasos**: Tech Spec listo para `tech-feasibility`
+
+## Notas
+
+- **Sin implementación técnica**: Esta skill solo produce documentación y acuerdos
+- **Enfoque PMBOK 8 Lite**: Mínimo indispensable, nada de burocracia pesada
+- **Compatible con side projects**: Diseñada para no añadir overhead innecesario
+- **Project Charter**: Solo como alias temporal; el nombre canónico es Project Framing Doc

--- a/project-init/SKILL.md
+++ b/project-init/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: project-init
+description: >
+  Skill para cerrar la brecha entre product-discovery y tech-feasibility.
+  Transforma hallazgos de discovery en un plan ejecutable para desarrollo.
+  Recibe como entrada el Discovery Report y produce un Project Framing Doc.
+
+  Usa esta skill cuando ya exista un Discovery Report con:
+  - Usuario principal identificado
+  - Problema validado
+  - Hipótesis de riesgos
+  - Señal de enfoque de desarrollo
+
+  El output principal es el Project Framing Doc (Project Charter como alias).
+
+license: Apache-2.0
+metadata:
+  author: KkapsCa
+  version: "1.0"
+  pipeline: "project-kickstart/03"
+  prev: "product-discovery"
+  next: "tech-feasibility"
+---
+
+# project-init — Skill de Transición
+
+> **Pipeline recomendado:** `brainstorm` → `product-discovery` → `project-init` → `tech-feasibility`
+> **Input:** Discovery Report de `product-discovery` (o Product Brief por bypass)
+> **Output:** Project Framing Doc (Project Charter como alias)
+
+---
+
+## When to Use
+
+Usa esta skill cuando el usuario necesite:
+
+- Decidir el enfoque de desarrollo (predictivo, adaptativo o híbrido)
+- Definir una secuencia de trabajo ligera para el proyecto
+- Estructurar el alcance inicial en épics y stories
+- Establecer acuerdos mínimos para avanzar sin ambigüedad
+
+## When NOT to Use
+
+- El proyecto ya es pequeno y el alcance ya está claro
+- El usuario es el único interesado y decisor
+- No hay restricciones regulatorias u organizacionales
+- En este caso, se puede usar el bypass: `brainstorm → product-discovery → tech-feasibility`
+
+---
+
+## Pre-flight Checklist
+
+- [ ] Existe un Discovery Report con enfoque sugerido
+- [ ] El problema y usuario ya están validados
+- [ ] Ya hay una señal clara del tipo de proyecto
+
+Si no hay suficiente claridad, volver a `product-discovery`.
+
+---
+
+## Filosofía
+
+project-init no es burocracia.
+Es el puente entre entender el problema y saber cómo construirlo.
+
+### Regla de oro
+
+> El mejor plan no es el más detallado.
+> Es el que permite avanzar sin bloquearse y que cabe en un sprint.
+
+---
+
+## Fase 1 — Selección de Enfoque de Desarrollo
+
+**Objetivo**: Decidir cómo se construirá el proyecto.
+
+**Pregunta clave**:
+> ¿Los requisitos son claros y estables, o van a evolucionar con feedback?
+
+**Marco de decisión**:
+
+| Señal | Enfoque recomendado | Justificación |
+|-------|---------------------|---------------|
+| Requisitos claros, entregable definido, cambio costoso | **Predictivo** | El alcance es fijo y los riesgos de cambio son altos |
+| Requisitos evolucionan, feedback continuo es clave | **Adaptativo (Ágil)** | El valor se entrega iterativamente, los cambios son baratos |
+| Mix de estable y evolutivo | **Híbrido** | Componentes regulatorios (predictivo) + desarrollo iterativo |
+
+**Output**:
+- `enfoque`: Predictivo / Adaptativo / Híbrido
+- `justificación`: Razón técnica y de negocio
+
+**Restricción**: No se puede continuar sin esta decisión.
+
+---
+
+## Fase 2 — Fases del Proyecto y Cadencia
+
+**Objetivo**: Definir el camino temporal del proyecto de manera ligera.
+
+**Actividades**:
+1. Definir fases del proyecto (máximo 4):
+   - Usa nombres que tengan sentido para el contexto real del proyecto
+   - Ejemplos válidos: descubrimiento → construcción → validación → release
+   - No fuerces un modelo universal si el proyecto no lo necesita
+
+2. Establecer cadencia (opcional para proyectos pequeños):
+   - Duración de iteración: 1, 2 o 4 semanas
+   - Quién revisa: decisor responsable / owner del backlog
+   - La revisión puede ser por iteración, por entregable o por milestone ligero
+
+3. Priorización:
+   - Método: backlog priorizado por valor
+   - Talla: S/M/L
+
+**Output**:
+- `fases`: Lista de fases
+- `cadencia`: Duración y frecuencia (opcional)
+- `quien_revisa`: Rol responsable
+
+---
+
+## Fase 3 — Alcance Estructurado Inicial
+
+**Objetivo**: Transformar el alcance en trabajo ejecutable para el primer sprint.
+
+**Entrada**: Discovery Report
+
+**Proceso**:
+1. Extraer los MUST-HAVE del discovery
+2. Convertir cada MUST-HAVE en user stories:
+   ```
+   Como [tipo de usuario],
+   quiero [funcionalidad],
+   para [resultado de valor]
+   ```
+3. Definir criterios de aceptación mínimos (solo para stories críticas)
+4. Estimar con tamaño S/M/L
+5. Limitar al primer sprint o primera iteración detallada
+6. Épics de alto nivel para el resto del roadmap
+
+**Output**:
+- `backlog_inicial`: User stories con aceptación
+- `epics`: Epics para desarrollo posterior
+- `talla`: Distribución S/M/L del sprint inicial
+
+**Regla**: El backlog debe ser suficiente para un sprint, pero no completo al 100%.
+
+---
+
+## Fase 4 — Gobernanza Mínima
+
+**Objetivo**: Acordar lo mínimo necesario para que el proyecto avance sin confusión.
+
+**Elementos esenciales (3 preguntas)**:
+
+1. **¿Cómo tomamos decisiones?**
+   - Consenso / Decisión del lead técnico / Autoridad única
+
+2. **¿Cómo gestionamos cambios de alcance?**
+    - Proceso informal (proyectos pequeños) o formal (proyectos grandes)
+
+3. **¿Qué necesita estar claro antes de pasar a la siguiente fase?**
+   - Ejemplo: decisión tomada / alcance suficientemente claro / backlog inicial priorizado
+
+**Definition of Done (mínimo y opcional)**:
+- Úsala solo si aporta claridad real al proyecto
+- Debe ser breve, adaptable y proporcional al tamaño del trabajo
+- No la conviertas en un checklist rígido si todavía están en framing
+
+**Output**:
+- `acuerdos`: Decisiones tomadas
+- `criterios_de_avance`: Señales mínimas para pasar de framing a factibilidad técnica
+
+---
+
+## Bypass — Cuándo Saltar project-init
+
+**Condiciones para usar bypass** (`brainstorm → product-discovery → tech-feasibility`):
+
+- Proyecto personal con alcance muy pequeño (1-2 features)
+- El usuario es el único interesado y decisor
+- No hay restricciones regulatorias ni organizacionales
+- tech-feasibility puede funcionar con el Discovery Report directo
+
+**En bypass**: `tech-feasibility` recibe el Discovery Report como input principal.
+
+---
+
+## Output Final — Project Framing Doc v1.0
+
+```markdown
+# [Nombre del Proyecto] — Project Framing Doc
+**Generado por:** project-init skill v1.0
+**Fecha:** [fecha]
+
+## 1. Enfoque de desarrollo
+- Enfoque: [Predictivo / Adaptativo / Híbrido]
+- Justificación: [por qué se eligió este enfoque]
+
+## 2. Fases del proyecto
+1. [Fase 1]
+2. [Fase 2]
+3. [Fase 3]
+4. [Fase 4]
+
+## 3. Cadencia (opcional)
+- Iteración: [1/2/4 semanas]
+- Quién revisa: [rol]
+- Frecuencia: [final de iteración / semanal / otro]
+
+## 4. Alcance inicial
+### User Stories del primer sprint
+- US1: Como [usuario], quiero [funcionalidad], para [valor]
+  - Aceptación: [criterios]
+  - Talla: [S/M/L]
+
+### Épics (resto del roadmap)
+- [Épica 1]
+- [Épica 2]
+
+## 5. Gobernanza mínima
+- Decisiones: [cómo se toman]
+- Cambios: [cómo se gestionan]
+- Criterios de avance: [qué debe estar claro para pasar a tech-feasibility]
+- Nota opcional: [DoD mínima solo si aplica]
+
+## 6. Stakeholders principales
+- [Stakeholder 1]: [rol]
+- [Stakeholder 2]: [rol]
+
+## 7. Siguiente paso
+- Pasar a tech-feasibility con este Project Framing Doc
+```
+
+---
+
+## Criterio de salida
+
+Esta skill está completa cuando ya existe:
+
+- ✅ un enfoque de desarrollo seleccionado con justificación
+- ✅ fases definidas de manera ligera
+- ✅ alcance inicial en user stories (mínimo 1 sprint)
+- ✅ gobernanza mínima acordada
+- ✅ criterios de avance claros hacia tech-feasibility
+- ✅ stakeholders principales identificados
+
+---
+
+## Referencias PMBOK 8
+
+- **Gobernanza**: 1.1 Iniciar Proyecto o Fase, 1.2 Integrar y Alinear Planes
+- **Alcance**: 2.1 Planificar Gestión del Alcance, 2.2 Obtener/Requisitos, 2.3-2.4 Definir Alcance
+- **Interesados**: 1.1-1.2 (identificación temprana)
+- **Enfoque**: 1.2 (selección adaptativa del método)

--- a/tech-feasibility/SKILL.md
+++ b/tech-feasibility/SKILL.md
@@ -1,26 +1,30 @@
 ---
 name: tech-feasibility
 description: >
-  PASO 3 de un pipeline de definición de producto. Evalúa factibilidad técnica,
+  PASO 4 de un pipeline de definición de producto. Evalúa factibilidad técnica,
   aterriza requisitos, identifica riesgos, propone una arquitectura proporcional
   al alcance y ayuda a elegir stack con un framework de decisión, no con recetas.
 
   Usa esta skill cuando ya exista claridad suficiente del problema, usuario y MVP,
   y haga falta decidir cómo construirlo, cuánto esfuerzo implica y qué riesgos técnicos
-  existen antes de arrancar el desarrollo.
+  existen antes de arrancar el desarrollo. Recibe input de project-init (o Discovery Report por bypass).
 
 license: Apache-2.0
 metadata:
   author: KkapsCa
-  version: "2.0"
-  pipeline: "project-kickstart/03"
-  prev: "product-discovery"
+  version: "3.0"
+  pipeline: "project-kickstart/04"
+  prev: "project-init"
+  next: ""
+  input_principal: "Project Framing Doc"
+  input_bypass: "Discovery Report"
 ---
 
-# Tech Feasibility — Step 3
+# Tech Feasibility — Step 4
 
-> **Pipeline recomendado:** `brainstorm` → `product-discovery` → `tech-feasibility`
-> **Input ideal:** Discovery Report, Product Brief o contexto suficientemente claro
+> **Pipeline recomendado:** `brainstorm` → `product-discovery` → `project-init` → `tech-feasibility`
+> **Input principal:** Project Framing Doc de `project-init`
+> **Input bypass:** Discovery Report (cuando se usa bypass de project-init)
 > **Output:** Tech Spec listo para iniciar implementación
 
 ---
@@ -108,7 +112,7 @@ Para cada feature del MVP, responde:
 
 ```text
 Feature: [nombre]
-────────────────────────────────────────
+──────────────────────────────────────
 ¿Necesita autenticación?         [ ] Sí  [ ] No
 ¿Necesita persistencia?          [ ] Sí  [ ] No
 ¿Necesita tiempo real?           [ ] Sí  [ ] No
@@ -127,7 +131,6 @@ Feature: [nombre]
 - latencia tolerable,
 - sensibilidad de datos,
 - regiones o idiomas,
-- restricciones regulatorias si existen,
 - presupuesto y tiempo disponibles.
 
 Sin este inventario, elegir stack es disparar a ciegas.
@@ -199,11 +202,6 @@ Presenta alternativas con contexto y tradeoffs.
 | **SQLite** | Estado/datos locales o modo offline en cliente |
 | **MongoDB** | Documentos y estructura cambiante, si el caso realmente lo pide |
 | **Redis** | Caché, colas o sesiones; no reemplaza tu base principal en la mayoría de casos |
-
-### Regla
-
-No digas “usa X”.
-Di: **“Dado A, B y C, X parece mejor que Y por estas razones.”**
 
 ---
 
@@ -322,8 +320,9 @@ Esta fase está completa cuando ya existe:
 
 ```markdown
 # [Nombre del Producto] — Tech Spec
-**Generado por:** tech-feasibility skill v2.0
+**Generado por:** tech-feasibility skill v3.0
 **Fecha:** [fecha]
+**Input usado:** [Project Framing Doc / Discovery Report por bypass]
 
 ## 1. Contexto
 - Tipo de proyecto: [aprendizaje / side project / producto / herramienta interna]


### PR DESCRIPTION
Closes #20

## Summary
- add a new `project-init` skill between discovery and technical feasibility to make the public pipeline explicit and PMBOK-lite aligned
- update the public skills and README to document the 4-step flow plus the lightweight bypass path for small projects
- keep internal PMBOK research and SDD planning artifacts out of git through explicit ignore rules in `.gitignore`

## Changes
| File | Change |
|------|--------|
| `.gitignore` | Exclude internal PMBOK and SDD planning artifacts from git |
| `README.md` | Document the public 4-step pipeline and bypass guidance |
| `brainstorm/SKILL.md` | Add PMBOK-lite stakeholder/value framing and update the output |
| `product-discovery/SKILL.md` | Route discovery into `project-init` and document transition rules |
| `project-init/SKILL.md` | Add the new lightweight framing stage between discovery and feasibility |
| `project-init/README.md` | Document quick usage, bypass conditions, and output naming |
| `tech-feasibility/SKILL.md` | Accept `Project Framing Doc` as primary input and `Discovery Report` as bypass fallback |

## Test Plan
- [x] Manual review of the changes
- [x] Verified the documentation consistency of the 4-step flow
- [x] Verified the 3-step bypass path for small projects
- [x] Verified internal PMBOK/SDD artifacts are ignored by git

## Contributor Checklist
- [x] Linked an approved issue (`status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format used
- [x] Docs updated if behavior changed
- [x] No `Co-Authored-By` trailers