### PR TITLE
docs: restructure readme as landing + add support docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,7 @@ En otras palabras:
 - **sí son reutilizables** fuera de ese ecosistema,
 - pero su mejor rendimiento aparece cuando se usan como **potenciador del stack de Gentle AI**.
 
-La filosofía es simple:
-
-- no correr al código sin entender el problema,
-- no elegir tecnologías por moda,
-- no meter complejidad antes de tiempo,
-- construir con fundamentos, no con ocurrencias.
+---
 
 ## Inicio rápido
 
@@ -28,184 +23,28 @@ cd kkapsca-skills
 bash scripts/bootstrap.sh
 ```
 
-Después:
+> **Nota**: El bootstrap se corre desde **este repo de skills**, no desde la carpeta de tu proyecto futuro.
 
-1. Reinicia opencode.
-2. Prueba una skill explícita, por ejemplo: `Usa la skill brainstorm`.
-3. Si todavía no tienes carpeta de proyecto, no pasa nada: puedes empezar con `brainstorm` o `product-discovery` antes de crearla.
+### ¿Qué hace el bootstrap?
 
-> El bootstrap se corre desde **este repo de skills**, no desde la carpeta de tu proyecto futuro.
+- Registra cada carpeta que contiene `SKILL.md`
+- Instala tanto las skills raíz como las de `dev-skills/`
+- Usa `~/.config/opencode/skills` por defecto (configurable vía `OPENCODE_SKILLS_DIR`)
+- Crea **symlinks** por defecto (ideal para mantener las skills actualizadas al hacer `git pull`)
 
-## Nota de entorno
-
-Si vas a usar **opencode en Windows**, la recomendación es correrlo bajo **WSL2** para mantener un entorno más consistente con Linux y evitar fricción innecesaria con rutas, shells y dependencias.
-
-Referencias útiles:
-
-- https://learn.microsoft.com/windows/wsl/
-- https://learn.microsoft.com/windows/wsl/install
-- https://learn.microsoft.com/windows/wsl/filesystems
-
----
-
-## Mejor experiencia de uso
-
-Estas skills están pensadas para ser útiles por sí solas, pero fueron afinadas para que den mejores resultados cuando:
-
-- el agente opera con contexto consistente,
-- existe un `sdd-orchestrator` coordinando fases o subagentes,
-- y el entorno ya sigue las convenciones del stack de Gentle AI.
-
-Si quieres la mejor experiencia de instalación, ejecución y contexto compartido, ve al repo de **Gentle AI** y sigue su guía:
-
-- https://github.com/Gentleman-Programming/gentle-ai
-
-La idea correcta no es vender estas skills como piezas aisladas mágicas, sino como un **potenciador del stack** para lograr mejor ejecución, menos ambigüedad y mejores resultados con agentes IA.
-
-### Windows + opencode
-
-- En Windows, usa **WSL2** como entorno base para opencode.
-- Evita mezclar rutas de Windows y Linux dentro del mismo flujo.
-- Si una guía o skill asume shell Unix, WSL te deja mucho más cerca de ese comportamiento real.
-
----
-
-## Qué contiene este repositorio
-
-```text
-KkapsCa-project-kickstart/
-├── README.md
-├── brainstorm/
-│   └── SKILL.md
-├── product-discovery/
-│   └── SKILL.md
-├── project-init/
-│   ├── SKILL.md
-│   └── README.md
-├── tech-feasibility/
-│   └── SKILL.md
-└── dev-skills/
-    ├── flutter-personal-standards/
-    │   └── SKILL.md
-    └── repo-bootstrap/
-        ├── SKILL.md
-        └── assets/
-```
-
-Se divide en dos grupos:
-
-### 1. Skills de inicio de proyecto
-Sirven para aterrizar una idea antes de construir.
-
-- **brainstorm** → convierte una idea vaga en un Product Brief.
-- **product-discovery** → valida mercado, usuario, competencia y negocio.
-- **project-init** → cierra la brecha entre discovery y factibilidad (opcional por bypass).
-- **tech-feasibility** → evalúa stack, riesgos, arquitectura y esfuerzo.
-
-### 2. Skills de desarrollo
-Sirven cuando el proyecto ya tiene claridad suficiente y toca implementar.
-
-- **dev-skills/flutter-personal-standards** → criterio personal para Flutter y puente hacia las skills oficiales.
-- **dev-skills/repo-bootstrap** → prepara el repositorio para ejecutar bien: PR workflow, hook local, release-please y estándares base.
-
-### 3. Skills internas / exclusivas de empresa
-Estas skills no se distribuyen en este repo público. Si existe una convención interna, vive en su repositorio o instalación privada correspondiente.
-
----
-
-## Pipeline recomendado
-
-El flujo ideal para un proyecto nuevo es este:
-
-```text
-Idea → brainstorm → product-discovery → project-init → tech-feasibility → repo-bootstrap → Desarrollo
-```
-
-**Ruta ligera (bypass de project-init)**:
-```text
-Idea → brainstorm → product-discovery → tech-feasibility → repo-bootstrap → Desarrollo
-```
-
-**Condiciones para bypass de project-init**:
-- Proyecto personal con alcance muy pequeño (1-2 features)
-- El usuario es el único interesado y decisor
-- No hay restricciones regulatorias ni organizacionales
-- tech-feasibility puede funcionar con Discovery Report directo
-
-Pero este repositorio **no es dogmático**.
-
-Si ya tienes trabajo previo real, puedes entrar más adelante en el pipeline.
-
-### Ejemplos
-
-- Si solo tienes una idea vaga → empieza en **brainstorm**.
-- Si ya tienes claro problema, usuario y MVP → puedes entrar en **product-discovery**.
-- Si ya tienes Discovery Report completo y quieres cerrar brecha → usa **project-init** (recomendado).
-- Si ya tienes claridad funcional y solo falta tech → entra en **tech-feasibility**.
-- Si ya tienes claridad funcional y técnica → usa una **dev-skill**.
-
-La regla no es "seguir pasos porque sí".
-La regla es **no saltarte el pensamiento que todavía no has hecho**.
-
----
-
-## Para quién sirve
-
-Este repo puede servirle a:
-
-- developers que arrancan proyectos desde cero,
-- founders técnicos,
-- builders indie,
-- estudiantes que quieren aprender a pensar antes de programar,
-- equipos pequeños que necesitan estructura sin caer en burocracia absurda.
-
----
-
-## Instalación para opencode
-
-Hoy este repo **no se autodetecta solo por existir en tu filesystem**. opencode lista las skills desde `~/.config/opencode/skills`, así que después de clonar el repo hay que registrarlas una vez.
-
-### Primer paso: Bootstrap local
-
-El método recomendado y más sencillo es usar el comando único de bootstrap. Esto garantiza que siempre uses el flujo correcto sin preocuparte por permisos de ejecución:
-
-```bash
-git clone https://github.com/KapsCa/kkapsca-skills.git
-cd kkapsca-skills
-bash scripts/bootstrap.sh
-```
-
-> **Nota**: `bash scripts/bootstrap.sh` funciona **siempre**, sin importar si los archivos tienen el bit de ejecución activado. Si prefieres usar `./scripts/bootstrap.sh`, asegúrate de que el archivo sea ejecutable (`chmod +x scripts/bootstrap.sh`).
-
-#### Opciones del bootstrap
-
-Por defecto, `bootstrap.sh` crea **symlinks** (ideal para mantener las skills actualizadas al hacer `git pull`). Si prefieres una copia física independiente:
+Si prefieres una copia física independiente:
 
 ```bash
 bash scripts/bootstrap.sh --copy
 ```
 
-Después de ejecutar el bootstrap, **reinicia opencode** para que refresque la lista de skills disponibles.
+> **Nota**: `bash scripts/bootstrap.sh` funciona **siempre**, sin importar si los archivos tienen el bit de ejecución activado.
 
-### ¿Desde qué carpeta se ejecuta?
+### Después del bootstrap
 
-El bootstrap se ejecuta desde la **carpeta de este repo de skills**, no desde la carpeta de tu proyecto futuro.
-
-Si ya tienes este repo clonado en tu máquina local, no necesitas clonarlo otra vez. Solo entra al repo y corre:
-
-```bash
-bash scripts/bootstrap.sh
-```
-
-Si todavía no lo tienes clonado, entonces sí:
-
-```bash
-git clone https://github.com/KapsCa/kkapsca-skills.git
-cd kkapsca-skills
-bash scripts/bootstrap.sh
-```
-
-La razón es simple: el script necesita saber dónde viven realmente `brainstorm/`, `product-discovery/`, `project-init/`, `tech-feasibility/` y `dev-skills/` para registrarlas en opencode.
+1. Reinicia opencode para refrescar la lista de skills disponibles.
+2. Prueba una skill explícita, por ejemplo: `Usa la skill brainstorm`.
+3. Si todavía no tienes carpeta de proyecto, no pasa nada: puedes empezar con `brainstorm` o `product-discovery` antes de crearla.
 
 ### ¿Necesito tener ya creada la carpeta del proyecto?
 
@@ -224,9 +63,9 @@ Flujo recomendado:
 Ejemplo práctico:
 
 ```text
-~/dev/kkapsca-skills   -> instalar skills
-~/dev/                 -> explorar idea
-~/dev/mi-nuevo-proyecto -> aterrizar e implementar
+~/dev/kkapsca-skills        -> instalar skills
+~/dev/                       -> explorar idea
+~/dev/mi-nuevo-proyecto      -> aterrizar e implementar
 ```
 
 ### Desinstalar
@@ -235,56 +74,119 @@ Ejemplo práctico:
 bash scripts/uninstall-opencode-skills.sh
 ```
 
-### Qué hace el instalador
+### Requisito de entorno (Windows)
 
-- registra cada carpeta que contiene `SKILL.md`
-- instala tanto las skills raíz como las de `dev-skills/`
-- usa `~/.config/opencode/skills` por defecto (configurable vía `OPENCODE_SKILLS_DIR`)
-- respeta conflictos si ya existe una skill con el mismo nombre y no fue instalada por este repo
-
-> Si quieres instalar en otra ubicación, exporta `OPENCODE_SKILLS_DIR=/ruta/destino` antes de correr el script.
+Si vas a usar **opencode en Windows**, la recomendación es correrlo bajo **WSL2** para mantener un entorno más consistente con Linux. Ver detalles en [docs/wsl-setup.md](docs/wsl-setup.md).
 
 ---
 
-### Aclaración importante: Engram vs Descubrimiento local
+## Qué incluye
 
-Es común confundir el papel de **Engram** con el registro de skills en opencode. Son cosas distintas y ambas cumplen roles diferentes:
+### 1. Skills de inicio de proyecto (brainstorm → discovery → factibilidad)
 
-| Concepto | ¿Qué hace? | ¿Registra skills en opencode? |
-|----------|------------|-------------------------------|
-| **Engram** | Guarda memoria persistente del proyecto, contexto, decisiones y flujos de trabajo entre sesiones. | ❌ No |
-| **Bootstrap / Instalador** | Crea symlinks o copias de las skills en `~/.config/opencode/skills` para que opencode las detecte. | ✅ Sí |
-| **`.atl/skill-registry.md`** | Catálogo de skills del proyecto para que el `sdd-orchestrator` resuelva estándares y reglas de proyecto. | ❌ No |
+Sirven para aterrizar una idea antes de construir.
 
-#### Resumen práctico
+| Skill | Propósito |
+|-------|-----------|
+| **brainstorm** | Convierte una idea vaga en un Product Brief |
+| **product-discovery** | Valida mercado, usuario, competencia y negocio |
+| **project-init** | Cierra la brecha entre discovery y factibilidad (opcional por bypass) |
+| **tech-feasibility** | Evalúa stack, riesgos, arquitectura y esfuerzo |
 
-1. **Engram** → memoria y contexto que sobrevive entre sesiones.
-2. **Bootstrap (`bash scripts/bootstrap.sh`)** → hace que opencode vea tus skills localmente.
-3. **`.atl/skill-registry.md`** → solo lo usa la orquestación SDD, no afecta la detección local de skills.
+### 2. Skills de desarrollo
 
-Si tu repo ya usa Engram, úsalo para recordar contexto y decisiones; **igual debes correr el bootstrap** para que opencode detecte las skills.
+Sirven cuando el proyecto ya tiene claridad suficiente y toca implementar.
 
----
+| Skill | Propósito |
+|-------|-----------|
+| **dev-skills/flutter-personal-standards** | Criterio personal para Flutter y puente hacia las skills oficiales |
+| **dev-skills/repo-bootstrap** | Prepara el repositorio: PR workflow, hook local, release-please y estándares base |
 
-## Cómo usarlo
+### 3. Skills futuras posibles
 
-### Si comienzas con una idea
-
-1. Usa `brainstorm`
-2. Continúa con `product-discovery`
-3. Sigue con `project-init` (o sáltala solo si aplica el bypass)
-4. Continúa con `tech-feasibility`
-5. Aplica `dev-skills/repo-bootstrap`
-6. Pasa a la skill de desarrollo adecuada
-
-### Si ya estás en etapa de implementación
-
-Ve directo a `dev-skills/` y usa la skill que corresponda al stack.
-Si el repo aún no tiene estándares operativos claros, aplica primero `repo-bootstrap`.
+backend, arquitectura, testing, bases de datos, automatización.
 
 ---
 
-## Filosofía del repositorio
+## Flujo recomendado
+
+### Pipeline ideal para un proyecto nuevo
+
+```text
+Idea → brainstorm → product-discovery → project-init → tech-feasibility → repo-bootstrap → Desarrollo
+```
+
+### Ruta ligera (bypass de project-init)
+
+```text
+Idea → brainstorm → product-discovery → tech-feasibility → repo-bootstrap → Desarrollo
+```
+
+**Condiciones para bypass de project-init**:
+- Proyecto personal con alcance muy pequeño (1-2 features)
+- El usuario es el único interesado y decisor
+- No hay restricciones regulatorias ni organizacionales
+- tech-feasibility puede funcionar con Discovery Report directo
+
+### Cómo elegir tu punto de entrada
+
+Este repositorio **no es dogmático**. Si ya tienes trabajo previo real, puedes entrar más adelante en el pipeline.
+
+- Si solo tienes una idea vaga → empieza en **brainstorm**
+- Si ya tienes claro problema, usuario y MVP → puedes entrar en **product-discovery**
+- Si ya tienes Discovery Report completo y quieres cerrar brecha → usa **project-init** (recomendado)
+- Si ya tienes claridad funcional y solo falta tech → entra en **tech-feasibility**
+- Si ya tienes claridad funcional y técnica → usa una **dev-skill**
+- Si ya estás en etapa de implementación → ve directo a `dev-skills/` y usa la skill que corresponda al stack
+
+La regla no es "seguir pasos porque sí". La regla es **no saltarte el pensamiento que todavía no has hecho**.
+
+---
+
+## Para quién sirve
+
+Este repo puede servirle a:
+
+- developers que arrancan proyectos desde cero
+- founders técnicos
+- builders indie
+- estudiantes que quieren aprender a pensar antes de programar
+- equipos pequeños que necesitan estructura sin caer en burocracia absurda
+
+---
+
+## Mejor experiencia de uso
+
+Estas skills están pensadas para ser útiles por sí solas, pero fueron afinadas para que den mejores resultados cuando:
+
+- el agente opera con contexto consistente
+- existe un `sdd-orchestrator` coordinando fases o subagentes
+- y el entorno ya sigue las convenciones del stack de Gentle AI
+
+Si quieres la mejor experiencia de instalación, ejecución y contexto compartido, ve al repo de **Gentle AI** y sigue su guía:
+
+- https://github.com/Gentleman-Programming/gentle-ai
+
+La idea correcta no es vender estas skills como piezas aisladas mágicas, sino como un **potenciador del stack** para lograr mejor ejecución, menos ambigüedad y mejores resultados con agentes IA.
+
+---
+
+## Referencia operativa
+
+Para detalles sobre configuración, gobernanza y contexto técnico, consulta la documentación en `docs/`:
+
+| Tema | Documento |
+|------|-----------|
+| Contexto Gentle AI y relación con este repo | [docs/gentle-ai.md](docs/gentle-ai.md) |
+| Engram vs Bootstrap vs Skill-Registry | [docs/engram.md](docs/engram.md) |
+| Configuración WSL para Windows | [docs/wsl-setup.md](docs/wsl-setup.md) |
+| Flujo de contribución, branch protection y Conventional Commits | [docs/governance.md](docs/governance.md) |
+| Versionado semántico y release-please | [docs/release-please.md](docs/release-please.md) |
+| Índice de documentación de soporte | [docs/README.md](docs/README.md) |
+
+---
+
+## Filosofía
 
 - **Problema primero, tecnología después**
 - **La arquitectura debe ser proporcional al proyecto**
@@ -292,106 +194,7 @@ Si el repo aún no tiene estándares operativos claros, aplica primero `repo-boo
 - **Aprender fundamentos siempre gana a memorizar frameworks**
 - **La IA ayuda, pero no reemplaza criterio técnico**
 
----
-
-## Estado actual
-
-Skills disponibles hoy:
-
-- `brainstorm` (Paso 1)
-- `product-discovery` (Paso 2)
-- `project-init` (Paso 3 — transición, opcional para proyectos pequeños)
-- `tech-feasibility` (Paso 4)
-- `flutter-personal-standards`
-- `repo-bootstrap`
-
-Skills futuras posibles:
-
-- backend
-- arquitectura
-- testing
-- bases de datos
-- automatización
-
----
-
-## Versionado y releases
-
-Este repositorio usa **release-please** para manejar versionado semántico, changelog y GitHub Releases.
-
-### Flujo
-
-1. Los cambios se integran por Pull Request usando Conventional Commits.
-2. Al llegar cambios a `main`, `release-please` analiza los commits.
-3. GitHub crea o actualiza un **Release PR** con versión y changelog.
-4. Al mergear ese Release PR, se publica el tag y el GitHub Release.
-
-### Tipos de commits y su impacto en versiones
-
-| Tipo de commit | ¿Dispara release? | Tipo de cambio |
-|----------------|-------------------|---------------|
-| `feat:` | ✅ Sí | minor (0.1.0 → 0.2.0) |
-| `fix:` | ✅ Sí | patch (0.0.1 → 0.0.2) |
-| `feat:` + `!` o `BREAKING CHANGE:` | ✅ Sí | major (0.1.0 → 1.0.0) |
-| `fix:` + `!` o `BREAKING CHANGE:` | ✅ Sí | major (0.1.0 → 1.0.0) |
-| `docs:` | ❌ No | — |
-| `chore:` | ❌ No | — |
-| `refactor:` | ❌ No | — |
-| `test:` | ❌ No | — |
-| `ci:` | ❌ No | — |
-| `build:` | ❌ No | — |
-| `style:` | ❌ No | — |
-| `perf:` | ❌ Tal vez* | — |
-| `[skip release]` | ❌ No | fuerza skip |
-
-> **Nota**: Commits de `perf:` pueden disparar release depending configuración, pero típicamente no lo hacen.
-
-### Release-please skip
-
-Para evitar que un commit dispare release, añade `[skip release]` o `[no-release]` en el mensaje:
-
-```bash
-git commit -m "chore: update deps [skip release]"
-```
-
-### Reglas de commits
-
-- `feat:` → minor
-- `fix:` → patch
-- `!` o `BREAKING CHANGE:` → major
-- `docs:`, `chore:`, `refactor:`, `test:`, `ci:` → normalmente no disparan release funcional
-
-La meta es NO versionar manualmente a mano ni mantener changelogs a puro copy-paste.
-
----
-
-## Protección de ramas
-
-### main branch protection
-
-Este repositorio **requiere** que la rama `main` tenga protección habilitada en GitHub:
-
-1. Ve a **Settings → Branches → Branch protection rules**
-2. Crea una regla para `main`
-3. Configura:
-   - ✅ **Require approvals** (al menos 1)
-   - ✅ **Require status checks to pass** antes de merge
-   - ✅ **Require conversation resolution** antes de merge
-   - ❌ **Allow force pushes** → NO permitido
-   - ❌ **Allow deletions** → NO permitido
-
-### Flujo de contribución
-
-1. **No seas ese wey que hace push directo a main** 😤
-2. Todo cambio entra por **Pull Request**
-3. El PR debe tener:
-   - Labels `type:*` y `status:approved`
-   - Referencia a issue (Closes #N)
-   - Commits en formato Conventional Commits
-   - Todos los status checks pasando
-4. **Auto-merge** solo después de validación exitosa
-
-La meta es mantener historial limpio, cambios trazables y releases automatizados sin intervención manual.
+No corras al código sin entender el problema. No elijas tecnologías por moda. No metas complejidad antes de tiempo. Construye con fundamentos, no con ocurrencias.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# Documentación de Soporte — KkapsCa Skills
+
+> **📚 Support Docs** — Esta sección contiene documentación operativa para usuarios y operación del repo.
+
+Este directorio contiene documentación operativa y de contexto para el uso de este repositorio. Si llegaste desde el [README principal](../README.md), aquí encontrarás el detalle de cada tema.
+
+## Orden de lectura recomendado
+
+1. **[README.md](../README.md)** — El landing principal: qué es, instalación rápida, flujo recomendado y inventario de skills.
+2. **[gentle-ai.md](gentle-ai.md)** — Contexto del stack Gentle AI y relación con este repositorio.
+3. **[engram.md](engram.md)** — Diferencia entre memoria persistente (Engram), bootstrap local y skill-registry.
+4. **[wsl-setup.md](wsl-setup.md)** — Recomendaciones para Windows/WSL y enlaces oficiales (solo si usas Windows).
+5. **[governance.md](governance.md)** — Flujo de contribución, branch protection, PR validation y Conventional Commits.
+6. **[release-please.md](release-please.md)** — Versionado semántico automático, tipos de commit y Release PR.
+
+## Archivos históricos (SDD)
+
+Este directorio también puede contener archivos generados por el flujo SDD (Spec-Driven Development), como:
+
+- `sdd-*-proposal.md`
+- `sdd-*-design.md`
+- `sdd-*-spec.md`
+- `sdd-*-tasks.md`
+- `sdd-*-archive.md`
+
+Estos no son documentación operativa; son artefactos de planeación de cambios. Para dudas sobre uso del repo, usa los docs listados arriba.

--- a/docs/branch-protection-settings.md
+++ b/docs/branch-protection-settings.md
@@ -1,48 +1,13 @@
-# Branch Protection Settings — Requerido en GitHub
+# Branch Protection Settings (Legacy)
 
-> **Nota**: Este archivo es histórico/complementario. El documento canónico para flujo de contribución, branch protection y Conventional Commits es **[docs/governance.md](governance.md)**.
->
-> Este archivo documenta la configuración necesaria de branch protection en GitHub. Los cambios deben aplicarse **manualmente en la interfaz de GitHub**; no pueden configurarse mediante archivos en el repositorio.
+Este archivo se conserva solo como referencia histórica.
 
-## Configuración requerida para `main`
+## Canonical source
 
-### En GitHub: Settings → Branches → Branch protection rules
+La fuente canónica para branch protection, flujo de contribución y Conventional Commits es:
 
-| Configuración | Valor |
-|-------------|-------|
-| Branch name pattern | `main` |
-| ✅ Require pull request reviews before merging | 1 approve required |
-| ✅ Require status checks to pass before merging | (selecciona los checks de PR validation) |
-| ✅ Require conversation resolution | enabled |
-| ✅ Require branches to be up to date before merging | enabled |
-| ❌ Allow force pushes | **DESACTIVADO** |
-| ❌ Allow deletions | **DESACTIVADO** |
-| ✅ Include administrators | enabled |
+- [docs/governance.md](governance.md)
 
-## Por qué esto importa
+## Qué hacer
 
-- **Sin protección en main**: anyone puede hacer push directo → se pierde trazabilidad
-- **Sin require approvals**: se pueden mergear cambios sin review
-- **Sin status checks**: cambios que no pasan validaciones pueden llegar a main
-
-## Workflow esperado
-
-```
-1. Crear branch feature/fix-descriptive-name
-2. Trabajar con commits Conventional Commits
-3. Abrir PR con labels type:*, status:approved
-4. esperar a que pase PR validation (incluye conventional commits check)
-5. una vez approvals + checks verdes → merge
-6. release-please detecta y crea Release PR
-7. al mergear Release PR → tag + release
-```
-
-##記住
-
-- Este documento es **solo lectura/reference**
-- La configuración real se hace en GitHub
-- Repo admins deben aplicar estos settings manualmente
-
----
-
-Para dudas sobre el flujo de contribución, ver README.md sección "Protección de ramas".
+Si necesitas configurar la rama `main` en GitHub, sigue únicamente `docs/governance.md`.

--- a/docs/branch-protection-settings.md
+++ b/docs/branch-protection-settings.md
@@ -1,5 +1,7 @@
 # Branch Protection Settings — Requerido en GitHub
 
+> **Nota**: Este archivo es histórico/complementario. El documento canónico para flujo de contribución, branch protection y Conventional Commits es **[docs/governance.md](governance.md)**.
+>
 > Este archivo documenta la configuración necesaria de branch protection en GitHub. Los cambios deben aplicarse **manualmente en la interfaz de GitHub**; no pueden configurarse mediante archivos en el repositorio.
 
 ## Configuración requerida para `main`

--- a/docs/engram.md
+++ b/docs/engram.md
@@ -1,0 +1,69 @@
+# Engram vs Bootstrap vs Skill-Registry
+
+Es común confundir el papel de **Engram** con el registro de skills en opencode. Son cosas distintas y ambas cumplen roles diferentes.
+
+## Comparación rápida
+
+| Concepto | ¿Qué hace? | ¿Registra skills en opencode? |
+|----------|------------|-------------------------------|
+| **Engram** | Guarda memoria persistente del proyecto, contexto, decisiones y flujos de trabajo entre sesiones. | ❌ No |
+| **Bootstrap / Instalador** | Crea symlinks o copias de las skills en `~/.config/opencode/skills` para que opencode las detecte. | ✅ Sí |
+| **`.atl/skill-registry.md`** | Catálogo de skills del proyecto para que el `sdd-orchestrator` resuelva estándares y reglas de proyecto. | ❌ No |
+
+## Engram — Memoria persistente
+
+Engram es un sistema de memoria que sobrevive entre sesiones y compactions. Permite:
+
+- Guardar decisiones de arquitectura y diseño
+- Recordar bugs fixeados y lecciones aprendidas
+- Mantener contexto de proyecto para el orquestador SDD
+- Buscar trabajo previo mediante búsqueda de texto completo (FTS5)
+
+### Cuándo usarlo
+- Después de hacer una decisión de arquitectura
+- Al completar un bug fix importante
+- Cuando estableces un patrón o convención
+- Al iniciar una sesión nueva (para recuperar contexto)
+
+### Ciclo de vida
+1. `mem_save` → guarda una observación
+2. `mem_search` → busca contexto previo
+3. `mem_get_observation` → recupera contenido completo
+4. `mem_session_summary` → cierra sesión con resumen
+
+## Bootstrap — Registro local de skills
+
+El script `scripts/bootstrap.sh` hace que opencode vea tus skills localmente:
+
+```bash
+git clone https://github.com/KapsCa/kkapsca-skills.git
+cd kkapsca-skills
+bash scripts/bootstrap.sh
+```
+
+Después de ejecutar el bootstrap, **reinicia opencode** para que refresque la lista de skills disponibles.
+
+### Opciones
+- Por defecto: crea **symlinks** (se actualizan con `git pull`)
+- Con `--copy`: crea copia física independiente
+
+### Desde qué carpeta se ejecuta
+El bootstrap se ejecuta desde la **carpeta de este repo de skills**, no desde la carpeta de tu proyecto futuro.
+
+## `.atl/skill-registry.md` — Catálogo para orquestación
+
+Este archivo es usado únicamente por el `sdd-orchestrator` para:
+
+- Resolver estándares de proyecto (compact rules)
+- Inyectar reglas en sub-agentes
+- Mapear triggers de skills a contextos de código
+
+No afecta la detección local de skills en opencode.
+
+## Resumen práctico
+
+1. **Engram** → memoria y contexto que sobrevive entre sesiones
+2. **Bootstrap (`bash scripts/bootstrap.sh`)** → hace que opencode vea tus skills localmente
+3. **`.atl/skill-registry.md`** → solo lo usa la orquestación SDD, no afecta la detección local de skills
+
+Si tu repo ya usa Engram, úsalo para recordar contexto y decisiones; **igual debes correr el bootstrap** para que opencode detecte las skills.

--- a/docs/gentle-ai.md
+++ b/docs/gentle-ai.md
@@ -1,0 +1,40 @@
+# Gentle AI y este repositorio
+
+Este repositorio de skills está diseñado para potenciar el flujo de trabajo asistido por IA, especialmente dentro del stack de **[Gentle AI](https://github.com/Gentleman-Programming/gentle-ai)**.
+
+## Qué es Gentle AI
+
+Gentle AI es un stack diseñado para coordinar agentes IA en flujos de desarrollo estructurados. Proporciona:
+
+- **`sdd-orchestrator`**: Coordinador de fases SDD (Spec-Driven Development)
+- Convenciones de contexto y memoria persistente
+- Flujos de trabajo validados para evitar "correr al código sin entender el problema"
+
+## Relación con este repositorio
+
+Las skills aquí reunidas:
+
+- **Son reutilizables fuera de Gentle AI** — cualquier persona puede usarlas con Cursor, Windsurf u opencode
+- **Dan su mejor rendimiento dentro del stack de Gentle AI** — cuando hay un `sdd-orchestrator` coordinando fases y el entorno sigue las convenciones del stack
+
+En otras palabras: no son piezas mágicas aisladas, son un **potenciador del stack** para lograr mejor ejecución, menos ambigüedad y mejores resultados con agentes IA.
+
+## Mejor experiencia de uso
+
+Para obtener la mejor experiencia de instalación, ejecución y contexto compartido:
+
+1. Ve al repo de **[Gentle AI](https://github.com/Gentleman-Programming/gentle-ai)**
+2. Sigue su guía de instalación y configuración
+3. Usa este repositorio de skills como complemento del stack
+
+## Filosofía compartida
+
+Lo que guía a Gentle AI también guía este repo:
+
+- **Problema primero, tecnología después**
+- **La arquitectura debe ser proporcional al proyecto**
+- **La validación barata vale más que el código caro**
+- **Aprender fundamentos siempre gana a memorizar frameworks**
+- **La IA ayuda, pero no reemplaza criterio técnico**
+
+Si quieres profundizar en el enfoque pedagógico y técnico, revisa el repo de Gentle AI.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,105 @@
+# Governance — Flujo de Contribución y Branch Protection
+
+Este documento describe las reglas operativas de este repositorio: protección de ramas, flujo de Pull Requests, validaciones y convenciones de commits.
+
+## Branch Protection en `main`
+
+Este repositorio **requiere** que la rama `main` tenga protección habilitada en GitHub. La configuración se aplica **manualmente en la interfaz de GitHub** (no se puede configurar mediante archivos en el repositorio).
+
+### Configuración requerida
+
+En GitHub: **Settings → Branches → Branch protection rules**
+
+| Configuración | Valor |
+|-------------|-------|
+| Branch name pattern | `main` |
+| ✅ Require pull request reviews before merging | 1 aprobación requerida |
+| ✅ Require status checks to pass before merging | selecciona los checks de PR validation |
+| ✅ Require conversation resolution | habilitado |
+| ✅ Require branches to be up to date before merging | habilitado |
+| ❌ Allow force pushes | **DESACTIVADO** |
+| ❌ Allow deletions | **DESACTIVADO** |
+| ✅ Include administrators | habilitado |
+
+### Por qué esto importa
+
+- **Sin protección en main**: cualquiera puede hacer push directo → se pierde trazabilidad
+- **Sin require approvals**: se pueden mergear cambios sin review
+- **Sin status checks**: cambios que no pasan validaciones pueden llegar a main
+
+## Flujo de Contribución
+
+Regla de oro: **No seas ese wey que hace push directo a main** 😤
+
+### Pasos
+
+1. Crear branch descriptivo: `feature/nombre-descriptivo` o `fix/nombre-descriptivo`
+2. Trabajar con commits en formato **Conventional Commits**
+3. Abrir Pull Request con:
+   - Labels `type:*` y `status:approved`
+   - Referencia a issue (ej. `Closes #N`)
+   - Todos los status checks pasando
+4. Esperar aprobación y validación
+5. **Auto-merge** solo después de validación exitosa + checks verdes
+
+### Workflow esperado
+
+```text
+1. Crear branch feature/fix-descriptive-name
+2. Trabajar con commits Conventional Commits
+3. Abrir PR con labels type:*, status:approved
+4. Esperar a que pase PR validation (incluye conventional commits check)
+5. Una vez approvals + checks verdes → merge
+6. release-please detecta y crea Release PR
+7. Al mergear Release PR → tag + release
+```
+
+## Conventional Commits
+
+Todos los commits deben seguir el estándar [Conventional Commits](https://www.conventionalcommits.org/):
+
+### Formato
+
+```text
+<tipo>(<área opcional>): <descripción corta>
+
+[body opcional]
+
+[footer opcional: Closes #N, [skip release], etc.]
+```
+
+### Tipos comunes
+
+| Tipo | ¿Cuándo usarlo? | ¿Dispara release? |
+|------|-----------------|-------------------|
+| `feat:` | Nueva funcionalidad | ✅ Sí (minor) |
+| `fix:` | Corrección de bug | ✅ Sí (patch) |
+| `docs:` | Cambios en documentación | ❌ No |
+| `chore:` | Mantenimiento, deps, config | ❌ No |
+| `refactor:` | Refactorización sin cambio funcional | ❌ No |
+| `test:` | Agregar o modificar tests | ❌ No |
+| `ci:` | Cambios en CI/CD | ❌ No |
+| `build:` | Cambios en build system | ❌ No |
+| `style:` | Formato, no cambios lógicos | ❌ No |
+| `perf:` | Mejoras de rendimiento | ❌ Tal vez* |
+
+### Breaking Changes
+
+Para cambios incompatibles (major version):
+
+```bash
+git commit -m "feat!: cambio que rompe compatibilidad"
+# o
+git commit -m "feat: nueva feature
+
+BREAKING CHANGE: se removió el endpoint /old-api"
+```
+
+## Reglas de releases
+
+- `feat:` → minor (0.1.0 → 0.2.0)
+- `fix:` → patch (0.0.1 → 0.0.2)
+- `!` o `BREAKING CHANGE:` → major (0.1.0 → 1.0.0)
+- `docs:`, `chore:`, `refactor:`, `test:`, `ci:` → normalmente no disparan release funcional
+
+La meta es NO versionar manualmente a mano ni mantener changelogs a puro copy-paste.

--- a/docs/release-please.md
+++ b/docs/release-please.md
@@ -1,0 +1,77 @@
+# Release-please — Versionado Automatizado
+
+Este repositorio usa **[release-please](https://github.com/googleapis/release-please)** para manejar versionado semántico, changelog y GitHub Releases de forma automática.
+
+## Qué hace release-please
+
+1. Analiza los commits en `main` que siguen **Conventional Commits**
+2. Determina el siguiente número de versión (major, minor, patch)
+3. Crea o actualiza un **Release PR** con changelog automático
+4. Al mergear ese Release PR, publica el tag y el GitHub Release
+
+## Flujo de versionado
+
+```text
+Cambios → Pull Request → Merge a main → release-please analiza commits → Crea/actualiza Release PR → Merge Release PR → Tag + GitHub Release
+```
+
+## Tipos de commits y su impacto
+
+| Tipo de commit | ¿Dispara release? | Tipo de cambio |
+|----------------|-------------------|---------------|
+| `feat:` | ✅ Sí | minor (0.1.0 → 0.2.0) |
+| `fix:` | ✅ Sí | patch (0.0.1 → 0.0.2) |
+| `feat:` + `!` o `BREAKING CHANGE:` | ✅ Sí | major (0.1.0 → 1.0.0) |
+| `fix:` + `!` o `BREAKING CHANGE:` | ✅ Sí | major (0.1.0 → 1.0.0) |
+| `docs:` | ❌ No | — |
+| `chore:` | ❌ No | — |
+| `refactor:` | ❌ No | — |
+| `test:` | ❌ No | — |
+| `ci:` | ❌ No | — |
+| `build:` | ❌ No | — |
+| `style:` | ❌ No | — |
+| `perf:` | ❌ Tal vez* | — |
+
+> **Nota**: Commits de `perf:` pueden disparar release dependiendo de la configuración, pero típicamente no lo hacen.
+
+## Reglas de versionado
+
+- `feat:` → minor
+- `fix:` → patch
+- `!` o `BREAKING CHANGE:` → major
+- `docs:`, `chore:`, `refactor:`, `test:`, `ci:` → normalmente no disparan release funcional
+
+## Skip release
+
+Para evitar que un commit dispare release, añade `[skip release]` o `[no-release]` en el mensaje:
+
+```bash
+git commit -m "chore: update deps [skip release]"
+```
+
+## Configuración de Conventional Commits
+
+Los commits deben seguir el formato:
+
+```text
+<tipo>(<área opcional>): <descripción corta>
+
+[body opcional]
+
+[footer opcional: Closes #N, [skip release], BREAKING CHANGE: ...]
+```
+
+### Ejemplos
+
+```bash
+git commit -m "feat: add new skill for database setup"
+git commit -m "fix: correct bootstrap symlink path"
+git commit -m "feat!: change skill registry format
+
+BREAKING CHANGE: skill-registry.md now requires version field"
+git commit -m "docs: update README structure [skip release]"
+```
+
+## La meta
+
+NO versionar manualmente a mano ni mantener changelogs a puro copy-paste. release-please automatiza todo el flujo de releases basado en los commits.

--- a/docs/wsl-setup.md
+++ b/docs/wsl-setup.md
@@ -1,0 +1,91 @@
+# Configuración WSL para opencode
+
+Si vas a usar **opencode en Windows**, la recomendación es correrlo bajo **WSL2** (Windows Subsystem for Linux) para mantener un entorno más consistente con Linux y evitar fricción innecesaria con rutas, shells y dependencias.
+
+## Por qué WSL2
+
+- Las herramientas de desarrollo (git, bash, scripts) asumen entorno Unix
+- WSL2 te deja mucho más cerca del comportamiento real esperado por las skills
+- Evita mezclar rutas de Windows (`C:\Users\...`) y Linux (`/home/...`) dentro del mismo flujo
+
+## Requisitos previos
+
+- Windows 10 versión 2004 o superior (Build 19041 o superior) o Windows 11
+- Virtualización habilitada en BIOS/UEFI
+
+## Instalación paso a paso
+
+### 1. Instalar WSL2
+
+Abre PowerShell **como administrador** y ejecuta:
+
+```powershell
+wsl --install
+```
+
+Esto instala WSL2 con Ubuntu por defecto. Reinicia después de la instalación.
+
+### 2. Verificar instalación
+
+```powershell
+wsl --list --verbose
+```
+
+Deberías ver algo como:
+
+```text
+NAME      STATE           VERSION
+* Ubuntu    Running         2
+```
+
+### 3. Acceder al entorno Linux
+
+Desde PowerShell o CMD:
+
+```powershell
+wsl
+```
+
+O abre "Ubuntu" desde el menú de inicio de Windows.
+
+### 4. Clonar repositorios dentro de WSL
+
+Usa el filesystem de Linux para evitar problemas de rendimiento y rutas:
+
+```bash
+cd ~
+mkdir -p dev/proyects
+cd dev/proyects
+git clone https://github.com/KapsCa/kkapsca-skills.git
+```
+
+### 5. Ejecutar bootstrap desde WSL
+
+```bash
+cd ~/dev/proyects/kkapsca-skills
+bash scripts/bootstrap.sh
+```
+
+## Recomendaciones adicionales
+
+- **Editor**: Usa VS Code con la extensión "Remote - WSL" para editar archivos dentro de WSL de forma transparente
+- **Paths**: Nunca mezcles rutas de Windows (`/mnt/c/Users/...`) con rutas de WSL (`/home/...`) en el mismo flujo
+- **Git**: Configura tu identidad de git dentro de WSL:
+
+```bash
+git config --global user.name "Tu Nombre"
+git config --global user.email "tu@email.com"
+```
+
+## Enlaces oficiales
+
+- [Instalación de WSL](https://learn.microsoft.com/windows/wsl/install)
+- [Documentación general de WSL](https://learn.microsoft.com/windows/wsl/)
+- [Sistemas de archivos en WSL](https://learn.microsoft.com/windows/wsl/filesystems)
+- [VS Code Remote - WSL](https://code.visualstudio.com/docs/remote/wsl)
+
+## Nota para Windows + opencode
+
+- En Windows, usa **WSL2** como entorno base para opencode
+- Evita ejecutar scripts de este repo directamente en CMD o PowerShell (usa WSL)
+- Si una guía o skill asume shell Unix, WSL te deja mucho más cerca de ese comportamiento real


### PR DESCRIPTION
Closes #28

## Summary
- reorganize the README into onboarding layers
- move operational details into docs
- keep the repo easier to scan for first-time users

## Checklist
- [x] Este PR está ligado a un issue aprobado ()
- [x] No hice push directo a main
- [x] Este cambio vive en una rama de trabajo
- [x] Usé Conventional Commits
- [x] Validé impacto funcional manual o con tests
- [x] Actualicé docs si era necesario
- [x] Consideré impacto en release
- [x] Este repo usa release-please y este cambio está pensado para convivir con ese flujo

## Release Please
- [x] docs / chore / refactor si no debe disparar release funcional

## Testing / Validación
- [x] Revisé manualmente el cambio
- [x] Corrí pruebas relevantes si existen

## Riesgos
- Bajo: cambio documental sin impacto funcional en runtime

## Evidencia
- README actualizado con inicio rápido y aclaraciones del flujo local