### PR TITLE
docs(readme): clarify public documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # KkapsCa Skills
 
-> Skills públicas para pasar de una idea a un producto y de un producto a una implementación técnica con criterio en un servicio de edición **AI-first**.
+> Habilidades (**Skills**) públicas para pasar de una idea a un producto y de un producto a una implementación técnica con criterio en un servicio de edición **IA-primero** (IA = Inteligencia Artificial).
 
 [![GitHub repo](https://img.shields.io/badge/GitHub-KkapsCa%2Fkkapsca--skills-blue?logo=github)](https://github.com/KapsCa/kkapsca-skills)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Follow Gentle AI](https://img.shields.io/badge/Follow-Gentle%20AI-purple?logo=github)](https://github.com/Gentleman-Programming/gentle-ai)
 
-Este repositorio reúne skills pensadas desde la experiencia personal de **KkapsCa**, optimizadas para flujos de trabajo asistidos por IA (como Cursor, Windsurf o **opencode**) y redactadas para que **cualquier persona pueda reutilizarlas** en sus propios proyectos.
+Este repositorio reúne habilidades (**skills**) pensadas desde la experiencia personal de **KkapsCa**, optimizadas para flujos de trabajo asistidos por Inteligencia Artificial (como Cursor, Windsurf o **opencode**) y redactadas para que **cualquier persona pueda reutilizarlas** en sus propios proyectos.
 
-Al mismo tiempo, estas skills están **optimizadas para trabajar especialmente bien dentro del stack de [Gentle AI](https://github.com/Gentleman-Programming/gentle-ai)** y flujos coordinados por **`sdd-orchestrator`**.
+Al mismo tiempo, estas habilidades están **optimizadas para trabajar especialmente bien dentro del entorno tecnológico de [Gentle AI](https://github.com/Gentleman-Programming/gentle-ai)** y flujos coordinados por el **orquestador sdd-orchestrator** (una herramienta que coordina fases de desarrollo estructurado).
 
 ---
 
-## Quickstart
+## Inicio Rápido
 
-Si quieres usar estas skills en tu máquina local con **opencode**:
+Si quieres usar estas habilidades en tu máquina local con **opencode**:
 
 ```bash
 git clone https://github.com/KapsCa/kkapsca-skills.git
@@ -22,66 +22,69 @@ cd kkapsca-skills
 bash scripts/bootstrap.sh
 ```
 
-> **Nota**: El bootstrap se corre desde **este repo de skills**, no desde la carpeta de tu proyecto futuro. Reinicia opencode después de ejecutarlo.
+> **Nota**: El proceso de inicialización (**bootstrap**) se corre desde **este repositorio de habilidades**, no desde la carpeta de tu proyecto futuro. Reinicia opencode después de ejecutarlo.
 
-Para detalles operativos de instalación (opciones `--copy`, symlinks, skills externas), consulta la [guía de instalación](docs/installation.md).
+Para detalles operativos de instalación (opciones `--copy`, enlaces simbólicos, habilidades externas), consulta la [guía de instalación](docs/installation.md).
+
+---
+
+## ¿Qué es esto y para quién es?
+
+Este repositorio es una colección de **habilidades (skills)** —conjuntos de instrucciones y flujos de trabajo— diseñadas para ayudarte a:
+
+- **Desarrolladores** que arrancan proyectos desde cero
+- **Creadores técnicos** que necesitan estructura sin burocracia
+- **Creadores independientes** que quieren validar antes de construir
+- **Estudiantes** que quieren aprender a pensar antes de programar
+- **Equipos pequeños** que necesitan flujos de trabajo consistentes
 
 ---
 
 ## Pipeline Recomendado
 
 ```text
-Idea → brainstorm → product-discovery → project-init → tech-feasibility → repo-bootstrap → Desarrollo
+Idea → brainstorming → descubrimiento de producto → inicio de proyecto → factibilidad técnica → bootstrap del repo → Desarrollo
 ```
 
-**Ruta ligera** (side projects / proyectos personales):
+**Ruta ligera** (proyectos personales o proyectos paralelos):
 ```text
-Idea → brainstorm → product-discovery → tech-feasibility → repo-bootstrap → Desarrollo
+Idea → brainstorming → descubrimiento de producto → factibilidad técnica → bootstrap del repo → Desarrollo
 ```
 
-¿Por dónde entrar?
-- Idea vaga → **brainstorm**
-- Ya tienes problema + usuario + MVP → **product-discovery**
-- Tienes Discovery Report → **project-init** o directo a **tech-feasibility**
-- Ya tienes claridad técnica → usa una **dev-skill**
+### ¿Por dónde entrar?
+
+- Idea vaga → **brainstorming** (herramienta para aterrizar ideas)
+- Ya tienes problema + usuario + MVP → **descubrimiento de producto**
+- Tienes Discovery Report → **inicio de proyecto** o directo a **factibilidad técnica**
+- Ya tienes claridad técnica → usa una **habilidad de desarrollo**
 
 > La regla no es "seguir pasos porque sí". La regla es **no saltarte el pensamiento que todavía no has hecho**.
 
 ---
 
-## Skills Disponibles
+## Habilidades Disponibles
 
-### 1. Inicio de proyecto (brainstorm → discovery → factibilidad)
+### 1. Inicio de proyecto (brainstorming → descubrimiento → factibilidad)
 
-| Skill | Propósito |
-|-------|-----------|
+| Habilidad | Propósito |
+|-----------|-----------|
 | **brainstorm** | Convierte una idea vaga en un Product Brief |
 | **product-discovery** | Valida mercado, usuario, competencia y negocio |
-| **project-init** | Cierra la brecha entre discovery y factibilidad |
-| **tech-feasibility** | Evalúa stack, riesgos, arquitectura y esfuerzo |
+| **project-init** | Cierra la brecha entre descubrimiento y factibilidad |
+| **tech-feasibility** | Evalúa tecnología, riesgos, arquitectura y esfuerzo |
 
 ### 2. Desarrollo y estándares
 
-| Skill | Propósito |
-|-------|-----------|
+| Habilidad | Propósito |
+|-----------|-----------|
 | **dev-skills/flutter-personal-standards** | Criterio personal para Flutter |
-| **dev-skills/repo-bootstrap** | Prepara el repositorio: PR workflow, release-please, estándares |
+| **dev-skills/repo-bootstrap** | Prepara el repositorio: flujo de PR, release-please, estándares |
 
-### 3. Skills especializadas (requieren stack confirmado)
+### 3. Habilidades especializadas (requieren tecnología confirmada)
 
-Las skills de **Supabase**, **Firebase** y **Genkit** se activan tras decidir el stack en `tech-feasibility`. Deben instalarse vía bootstrap para que opencode las detecte.
+Las habilidades de **Supabase**, **Firebase** y **Genkit** se activan tras decidir la tecnología en `tech-feasibility`. Deben instalarse vía bootstrap para que opencode las detecte.
 
-Consulta la [guía de instalación](docs/installation.md) para disponibilidad real y `docs/engram.md` para entender cómo se separan bootstrap, memoria persistente y orquestación.
-
----
-
-## Para quién sirve
-
-- Developers que arrancan proyectos desde cero
-- Founders técnicos
-- Builders indie
-- Estudiantes que quieren aprender a pensar antes de programar
-- Equipos pequeños que necesitan estructura sin burocracia absurda
+Consulta la [guía de instalación](docs/installation.md) para disponibilidad real y `docs/engram.md` para entender cómo se separan inicialización, memoria persistente y orquestación.
 
 ---
 
@@ -103,7 +106,8 @@ Para detalles operativos, consulta la documentación en `docs/`:
 |------|-----------|
 | Contexto Gentle AI y relación con este repo | [docs/gentle-ai.md](docs/gentle-ai.md) |
 | Instalación detallada, bootstrap y skill-registry | [docs/installation.md](docs/installation.md) |
-| Engram vs Bootstrap vs Skill-Registry | [docs/engram.md](docs/engram.md) |
+| Memoria persistente (Engram) vs Bootstrap vs Skill-Registry | [docs/engram.md](docs/engram.md) |
+| Desarrollo estructurado (SDD) y sdd-orchestrator | [docs/sdd.md](docs/sdd.md) |
 | Flujo de contribución y branch protection | [docs/governance.md](docs/governance.md) |
 | Versionado semántico y release-please | [docs/release-please.md](docs/release-please.md) |
 | Configuración WSL para Windows | [docs/wsl-setup.md](docs/wsl-setup.md) |
@@ -113,10 +117,11 @@ Para detalles operativos, consulta la documentación en `docs/`:
 
 ## Mejor Experiencia de Uso
 
-Estas skills dan mejores resultados cuando:
+Estas habilidades dan mejores resultados cuando:
+
 - El agente opera con contexto consistente
-- Existe un `sdd-orchestrator` coordinando fases o subagentes
-- Y el entorno ya sigue las convenciones del stack de Gentle AI
+- Existe un **orquestador sdd-orchestrator** coordinando fases o subagentes
+- Y el entorno ya sigue las convenciones del entorno tecnológico de Gentle AI
 
 Si quieres la mejor experiencia: [Gentle AI Repository](https://github.com/Gentleman-Programming/gentle-ai)
 
@@ -124,7 +129,14 @@ Si quieres la mejor experiencia: [Gentle AI Repository](https://github.com/Gentl
 
 ## Agradecimientos
 
-Gracias a [Gentleman-Programming/gentle-ai](https://github.com/Gentleman-Programming/gentle-ai) por la herramienta que permitió revisar, corregir y refinar este repositorio.
+Este proyecto utiliza herramientas y referentes que han contribuido a su desarrollo:
+
+- **[Gentleman-Programming/gentle-ai](https://github.com/Gentleman-Programming/gentle-ai)**: Por el entorno de trabajo, la filosofía de desarrollo y las herramientas que permitieron revisar, corregir y refinar este repositorio.
+- **Supabase**: Por sus habilidades oficiales que extienden las capacidades de este repositorio.
+- **Firebase**: Por sus habilidades oficiales que cubren casos de uso específicos en la plataforma.
+- **Equipo de opencode**: Por la plataforma que hace posible la ejecución de estas habilidades.
+
+Este repositorio es un esfuerzo personal y no cuenta con patrocinio oficial de ninguna de las herramientas mencionadas. Las menciones se realizan únicamente para referencia técnica y reconocimiento de uso.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,15 +1,18 @@
 # Documentación de Soporte — KkapsCa Skills
 
-> **📚 Support Docs** — Esta sección contiene documentación operativa para usuarios y operación del repo.
+> **📚 Docs de Soporte** — Esta sección contiene documentación operativa para usuarios y gestión del repositorio.
 
-Este directorio contiene documentación operativa y de contexto para el uso de este repositorio. Si llegaste desde el [README principal](../README.md), aquí encontrarás el detalle de cada tema.
+Este directorio contiene documentación operativa y de contexto para el uso de este repositorio de habilidades (**skills**). Si llegaste desde el [README principal](../README.md), aquí encontrarás el detalle de cada tema.
+
+Las habilidades se gestionan mediante el sistema **Skills.sh**, que coordina la instalación, registro y orquestación de las mismas en tu entorno local.
 
 ## Orden de lectura recomendado
 
-1. **[README.md](../README.md)** — El landing principal: qué es, instalación rápida, flujo recomendado y inventario de skills.
+1. **[README.md](../README.md)** — La página principal: qué es el repositorio, instalación rápida, flujo recomendado e inventario de habilidades (skills).
 2. **[gentle-ai.md](gentle-ai.md)** — Contexto del stack Gentle AI y relación con este repositorio.
-3. **[installation.md](installation.md)** — Guía detallada de instalación, bootstrap, symlinks y skills externas.
-4. **[engram.md](engram.md)** — Diferencia entre memoria persistente (Engram), bootstrap local y skill-registry.
-5. **[wsl-setup.md](wsl-setup.md)** — Recomendaciones para Windows/WSL y enlaces oficiales (solo si usas Windows).
-6. **[governance.md](governance.md)** — Flujo de contribución, branch protection, PR validation y Conventional Commits.
-7. **[release-please.md](release-please.md)** — Versionado semántico automático, tipos de commit y Release PR.
+3. **[installation.md](installation.md)** — Guía detallada de instalación, inicialización (bootstrap), enlaces simbólicos y habilidades externas.
+4. **[sdd.md](sdd.md)** — Desarrollo Guiado por Especificaciones (SDD) y el orquestador sdd-orchestrator.
+5. **[engram.md](engram.md)** — Diferencia entre memoria persistente (Engram), inicialización local y skill-registry.
+6. **[wsl-setup.md](wsl-setup.md)** — Recomendaciones para Windows/WSL y enlaces oficiales (solo si usas Windows).
+7. **[governance.md](governance.md)** — Flujo de contribución, protección de ramas, validación de PR y Conventional Commits.
+8. **[release-please.md](release-please.md)** — Versionado semántico automático, tipos de commit y Release PR.

--- a/docs/engram.md
+++ b/docs/engram.md
@@ -1,28 +1,41 @@
-# Engram vs Bootstrap vs Skill-Registry
+# Engram — Memoria Persistente para Desarrollo
 
-Es común confundir el papel de **Engram** con el registro de skills en opencode. Son cosas distintas y ambas cumplen roles diferentes.
+**Engram** es un sistema de memoria persistente diseñado para entornos de desarrollo asistidos por Inteligencia Artificial. Su propósito es mantener contexto, decisiones y flujos de trabajo entre sesiones de desarrollo, incluso después de reinicios o compresiones de contexto (compactions) del agente.
 
-## Comparación rápida
+## ¿Por qué usamos Engram en este repositorio?
+
+Este repositorio de habilidades (**skills**) utiliza Engram para:
+
+- **Recordar decisiones de arquitectura** tomadas durante el desarrollo de las habilidades
+- **Mantener contexto de proyecto** para que el orquestador SDD (**sdd-orchestrator**) tenga información histórica
+- **Guardar patrones y convenciones** establecidos mientras se escriben las habilidades
+- **Recuperar trabajo previo** mediante búsqueda de texto completo (FTS5)
+
+Al usar Engram, las sesiones de desarrollo no empiezan desde cero: el agente puede recuperar qué se hizo, qué decisiones se tomaron y qué problemas se resolvieron anteriormente.
+
+## Comparación rápida: Engram vs Bootstrap vs Skill-Registry
+
+Es común confundir el papel de **Engram** con el registro de habilidades en opencode. Son cosas distintas y ambas cumplen roles diferentes.
 
 | Concepto | ¿Qué hace? | ¿Registra skills en opencode? |
 |----------|------------|-------------------------------|
 | **Engram** | Guarda memoria persistente del proyecto, contexto, decisiones y flujos de trabajo entre sesiones. | ❌ No |
-| **Bootstrap / Instalador** | Crea symlinks o copias de las skills en `~/.config/opencode/skills` para que opencode las detecte. | ✅ Sí |
+| **Bootstrap / Instalador** | Crea enlaces simbólicos o copias de las skills en `~/.config/opencode/skills` para que opencode las detecte. | ✅ Sí |
 | **`.atl/skill-registry.md`** | Catálogo de skills del proyecto para que el `sdd-orchestrator` resuelva estándares y reglas de proyecto. | ❌ No |
 
 ## Engram — Memoria persistente
 
-Engram es un sistema de memoria que sobrevive entre sesiones y compactions. Permite:
+Engram es un sistema de memoria que sobrevive entre sesiones y compresiones de contexto (compactions). Permite:
 
 - Guardar decisiones de arquitectura y diseño
-- Recordar bugs fixeados y lecciones aprendidas
+- Recordar errores corregidos y lecciones aprendidas
 - Mantener contexto de proyecto para el orquestador SDD
 - Buscar trabajo previo mediante búsqueda de texto completo (FTS5)
 
 ### Cuándo usarlo
 
 - Después de hacer una decisión de arquitectura
-- Al completar un bug fix importante
+- Al completar una corrección de error importante
 - Cuando estableces un patrón o convención
 - Al iniciar una sesión nueva (para recuperar contexto)
 
@@ -47,7 +60,7 @@ Después de ejecutar el bootstrap, **reinicia opencode** para que refresque la l
 
 ### Opciones
 
-- Por defecto: crea **symlinks** (se actualizan con `git pull`)
+- Por defecto: crea **enlaces simbólicos** (se actualizan con `git pull`)
 - Con `--copy`: crea copia física independiente
 
 ### Desde qué carpeta se ejecuta
@@ -58,9 +71,9 @@ El bootstrap se ejecuta desde la **carpeta de este repo de skills**, no desde la
 
 Este archivo es usado únicamente por el `sdd-orchestrator` para:
 
-- Resolver estándares de proyecto (compact rules)
+- Resolver estándares de proyecto (reglas compactas)
 - Inyectar reglas en sub-agentes
-- Mapear triggers de skills a contextos de código
+- Mapear disparadores (**triggers**) de skills a contextos de código
 
 No afecta la detección local de skills en opencode.
 
@@ -92,20 +105,20 @@ Es fundamental entender que:
 
 Si el registry dice "activa `supabase` tras stack confirmado", eso es solo una **regla de orquestación lógica** para el `sdd-orchestrator`. Para que opencode realmente use esa skill, debes:
 
-1. Tener la skill en `~/.config/opencode/skills/supabase/` (vía symlink o copia)
+1. Tener la skill en `~/.config/opencode/skills/supabase/` (vía enlace simbólico o copia)
 2. Reiniciar opencode para refrescar la lista de skills
 
-Si la skill no está físicamente instalada, el routing fallará silenciosamente (el orquestador pedirá la skill, pero opencode no la tendrá disponible).
+Si la skill no está físicamente instalada, el enrutamiento (routing) fallará silenciosamente (el orquestador pedirá la skill, pero opencode no la tendrá disponible).
 
 ## Resumen práctico
 
 1. **Engram** → memoria y contexto que sobrevive entre sesiones
 2. **Bootstrap (`bash scripts/bootstrap.sh`)** → hace que opencode vea las skills del repo localmente
 3. **`.atl/skill-registry.md`** → solo lo usa la orquestación SDD, no afecta la detección local de skills
-4. **Skills externas** (como `supabase` y Firebase) → el bootstrap las procesa por default desde la carpeta configurada en `EXTERNAL_SKILLS_DIR`; usa esa variable solo si quieres otra fuente
+4. **Skills externas** (como `supabase` y Firebase) → el bootstrap las procesa por defecto desde la carpeta configurada en `EXTERNAL_SKILLS_DIR`; usa esa variable solo si quieres otra fuente
 5. **Firebase skills** → no activar solo por mencionar Firebase; requieren contexto técnico específico o confirmación de stack
 
-Si tu repo ya usa Engram, úsalo para recordar contexto y decisiones; **igual debes correr el bootstrap** para que opencode detecte las skills del repo. Para skills externas, documenta la dependencia y proporciona guidance de instalación. No activar skills Firebase prematuramente.
+Si tu repo ya usa Engram, úsalo para recordar contexto y decisiones; **igual debes correr el bootstrap** para que opencode detecte las skills del repo. Para skills externas, documenta la dependencia y proporciona una guía de instalación. No actives skills de Firebase prematuramente.
 
 ## Evaluación de `scripts/install-opencode-skills.sh` para Skills Externas
 
@@ -136,7 +149,7 @@ Si el bootstrap no se ejecutó todavía, tienes dos opciones equivalentes:
 # Opción A: bootstrap por defecto (usa ${HOME}/.agents/skills)
 bash scripts/bootstrap.sh
 
-# Opción B: symlinks manuales
+# Opción B: enlaces simbólicos manuales
 ln -s ${HOME}/.agents/skills/supabase ~/.config/opencode/skills/supabase
 ln -s ${HOME}/.agents/skills/supabase-postgres-best-practices ~/.config/opencode/skills/supabase-postgres-best-practices
 ```
@@ -147,6 +160,6 @@ Para Firebase, aplica el mismo patrón (o sobrescribe `EXTERNAL_SKILLS_DIR` si t
 bash scripts/bootstrap.sh
 ```
 
-Sin ese paso, el routing del registry fallará silenciosamente (el orquestador pedirá la skill, pero opencode no la tendrá disponible).
+Sin ese paso, el enrutamiento del registry fallará silenciosamente (el orquestador pedirá la skill, pero opencode no la tendrá disponible).
 
-> **Regla crítica**: No activar skills Firebase solo por mencionar Firebase. Cada skill requiere contexto técnico específico o confirmación de stack en `tech-feasibility`. Sin instalación física, el routing fallará silenciosamente.
+> **Regla crítica**: No activar skills Firebase solo por mencionar Firebase. Cada skill requiere contexto técnico específico o confirmación de stack en `tech-feasibility`. Sin instalación física, el enrutamiento (routing) fallará silenciosamente.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Instalación Detallada — KkapsCa Skills
 
-Este documento cubre el detalle operativo de instalación de las skills en tu entorno local.
+Este documento cubre el detalle operativo de instalación de las habilidades (**skills**) en tu entorno local usando el sistema **Skills.sh**.
 
 ## Inicio Rápido
 
@@ -10,12 +10,12 @@ cd kkapsca-skills
 bash scripts/bootstrap.sh
 ```
 
-> **Nota**: El bootstrap se corre desde **este repo de skills**, no desde la carpeta de tu proyecto futuro.
+> **Nota**: El proceso de inicialización (**bootstrap**) se corre desde **este repositorio de habilidades**, no desde la carpeta de tu proyecto futuro.
 
 ### Después del bootstrap
 
-1. Reinicia opencode para refrescar la lista de skills disponibles.
-2. Prueba una skill explícita, por ejemplo: `Usa la skill brainstorm`.
+1. Reinicia opencode para refrescar la lista de habilidades disponibles.
+2. Prueba una habilidad explícita, por ejemplo: `Usa la habilidad brainstorm`.
 3. Si todavía no tienes carpeta de proyecto, no pasa nada: puedes empezar con `brainstorm` o `product-discovery` antes de crearla.
 
 ---
@@ -23,43 +23,51 @@ bash scripts/bootstrap.sh
 ## ¿Qué hace el bootstrap?
 
 - Registra cada carpeta que contiene `SKILL.md`
-- Instala tanto las skills raíz como las de `dev-skills/`
+- Instala tanto las habilidades raíz como las de `dev-skills/`
 - Usa `~/.config/opencode/skills` por defecto (configurable vía `OPENCODE_SKILLS_DIR`)
-- Crea **symlinks** por defecto (ideal para mantener las skills actualizadas al hacer `git pull`)
+- Crea **enlaces simbólicos** por defecto (ideal para mantener las habilidades actualizadas al hacer `git pull`)
 
 ### Opciones de instalación
 
-**Symlinks (por defecto)**:
+**Enlaces simbólicos (por defecto)**:
 ```bash
 bash scripts/bootstrap.sh
 ```
-Ventaja: al hacer `git pull` en el repo de skills, los cambios se reflejan automáticamente.
+Ventaja: al hacer `git pull` en el repositorio de habilidades, los cambios se reflejan automáticamente.
 
 **Copia física independiente**:
 ```bash
 bash scripts/bootstrap.sh --copy
 ```
-Ventaja: las skills son independientes del repo original.
+Ventaja: las habilidades son independientes del repositorio original.
 
 > **Nota**: `bash scripts/bootstrap.sh` funciona **siempre**, sin importar si los archivos tienen el bit de ejecución activado.
 
 ---
 
-## Skills Externas (Supabase, Firebase, Genkit)
+## Habilidades Externas (Supabase, Firebase, Genkit)
 
-Las skills de Supabase y Firebase residen en una carpeta externa (por defecto `~/.agents/skills/`). El bootstrap las procesa automáticamente:
+Las habilidades de **Supabase** y **Firebase** provienen de las habilidades oficiales creadas por las respectivas plataformas. En este repositorio se integran para usarlas bajo el flujo de **Skills.sh**. Residen en una carpeta externa (por defecto `~/.agents/skills/`). El bootstrap las procesa automáticamente:
 
 ```bash
 # El bootstrap toma por defecto ~/.agents/skills como fuente externa
 bash scripts/bootstrap.sh
 ```
 
+### Origen de las habilidades oficiales
+
+| Plataforma | Habilidad | Origen Oficial |
+|------------|-----------|----------------|
+| **Supabase** | `supabase`, `supabase-postgres-best-practices` | Habilidades oficiales de Supabase adaptadas para el flujo de Skills.sh |
+| **Firebase** | `firebase-*` (10 habilidades) | Habilidades oficiales de Firebase adaptadas para el flujo de Skills.sh |
+| **Genkit** | `developing-genkit-*` | Habilidades oficiales de Genkit adaptadas para el flujo de Skills.sh |
+
 ### Rutas configurables
 
 | Variable | Valor por defecto | Propósito |
 |----------|-------------------|-----------|
-| `OPENCODE_SKILLS_DIR` | `~/.config/opencode/skills` | Dónde se instalan las skills |
-| `EXTERNAL_SKILLS_DIR` | `~/.agents/skills` | Fuente de skills externas |
+| `OPENCODE_SKILLS_DIR` | `~/.config/opencode/skills` | Dónde se instalan las habilidades |
+| `EXTERNAL_SKILLS_DIR` | `~/.agents/skills` | Fuente de habilidades externas |
 
 ---
 
@@ -73,22 +81,22 @@ bash scripts/uninstall-opencode-skills.sh
 
 ## ¿Necesito tener ya creada la carpeta del proyecto?
 
-**No para instalar las skills.**
+**No para instalar las habilidades.**
 
-Puedes instalar las skills una sola vez en tu máquina local y luego usarlas para pensar o descubrir ideas aunque todavía no exista la carpeta final del proyecto.
+Puedes instalar las habilidades una sola vez en tu máquina local y luego usarlas para pensar o descubrir ideas aunque todavía no exista la carpeta final del proyecto.
 
 ### Flujo recomendado
 
-1. Clona este repo de skills.
+1. Clona este repositorio de habilidades.
 2. Ejecuta `bash scripts/bootstrap.sh` una sola vez.
 3. Usa `brainstorm` o `product-discovery` para aterrizar la idea.
 4. Cuando la idea ya tenga forma, crea la carpeta real del proyecto.
-5. Desde esa carpeta sigue con `project-init`, `tech-feasibility` o la skill de desarrollo que aplique.
+5. Desde esa carpeta sigue con `project-init`, `tech-feasibility` o la habilidad de desarrollo que aplique.
 
 ### Ejemplo práctico
 
 ```text
-~/dev/kkapsca-skills        -> instalar skills
+~/dev/kkapsca-skills        -> instalar habilidades
 ~/dev/                       -> explorar idea
 ~/dev/mi-nuevo-proyecto      -> aterrizar e implementar
 ```
@@ -101,22 +109,22 @@ Si vas a usar **opencode en Windows**, la recomendación es correrlo bajo **WSL2
 
 ---
 
-## Enrutamiento de Skills por Stack
+## Enrutamiento de Habilidades por Stack
 
-Este repositorio usa un registro interno de skills para definir **orquestación lógica** (qué skill activar según el contexto), pero **no instala skills automáticamente**.
+Este repositorio usa un registro interno de habilidades para definir **orquestación lógica** (qué habilidad activar según el contexto), pero **no instala habilidades automáticamente**.
 
-### Cuándo se activa cada skill de Supabase
+### Cuándo se activa cada habilidad de Supabase
 
-| Skill | Cuándo se activa | Requiere stack confirmado |
-|-------|------------------|---------------------------|
+| Habilidad | Cuándo se activa | Requiere stack confirmado |
+|-----------|------------------|---------------------------|
 | `supabase` | Tras decidir Supabase en `tech-feasibility`; fases de diseño/implementación | ✅ Sí |
 | `supabase-postgres-best-practices` | En fases de diseño/apply con trabajo SQL, RLS, migrations o esquema Postgres | ✅ Sí + contexto técnico |
 | `skill-creator` | Solo referencia documental; NO participa en routing normal | ❌ No |
 
-### Cuándo se activa cada skill de Firebase
+### Cuándo se activa cada habilidad de Firebase
 
-| Skill | Cuándo se activa | Requiere stack confirmado |
-|-------|------------------|---------------------------|
+| Habilidad | Cuándo se activa | Requiere stack confirmado |
+|-----------|------------------|---------------------------|
 | `firebase-basics` | Tras decidir Firebase en `tech-feasibility` o setup de proyecto Firebase | ✅ Sí |
 | `firebase-auth-basics` | Con trabajo específico de Auth/sign-in/providers/tokens | ✅ Sí + contexto técnico |
 | `firebase-firestore-standard` | Con trabajo de Firestore Standard (queries, índices, SDK, reglas) | ✅ Sí + contexto técnico |
@@ -128,19 +136,19 @@ Este repositorio usa un registro interno de skills para definir **orquestación 
 | `firebase-ai-logic-basics` | Para Firebase AI Logic/Gemini desde cliente | ✅ Sí + contexto de IA |
 | `developing-genkit-js` | Para Genkit en JS/TS | ✅ Sí + stack JS/TS |
 
-> **Importante**: No activar skills Firebase solo por mencionar Firebase. Cada skill requiere contexto técnico específico o confirmación de stack.
+> **Importante**: No activar habilidades Firebase solo por mencionar Firebase. Cada habilidad requiere contexto técnico específico o confirmación de stack.
 
 ### Separación: Pipeline vs Disponibilidad Real
 
 ```
-Pipeline/Registry (lógico)  →  Define CUÁNDO activar skills
+Pipeline/Registry (lógico)  →  Define CUÁNDO activar habilidades
          ↓
-Bootstrap/Scripts (físico)  →  Hace que opencode DETECTE las skills
+Bootstrap/Scripts (físico)  →  Hace que opencode DETECTE las habilidades
 ```
 
-- **Pipeline/Registry**: la orquestación interna decide cuándo activar una skill tras confirmar el stack en `tech-feasibility`
-- **Bootstrap**: `scripts/install-opencode-skills.sh` instala skills del repo a `~/.config/opencode/skills/`
-- **Brecha actual**: Las skills externas requieren bootstrap + reinicio de opencode para quedar disponibles
+- **Pipeline/Registry**: la orquestación interna decide cuándo activar una habilidad tras confirmar el stack en `tech-feasibility`
+- **Bootstrap**: `scripts/install-opencode-skills.sh` instala habilidades del repo a `~/.config/opencode/skills/`
+- **Brecha actual**: Las habilidades externas requieren bootstrap + reinicio de opencode para quedar disponibles
 
 ---
 
@@ -148,3 +156,4 @@ Bootstrap/Scripts (físico)  →  Hace que opencode DETECTE las skills
 
 - [Gentle AI Repository](https://github.com/Gentleman-Programming/gentle-ai) — Contexto del stack y mejor experiencia de uso
 - [docs/engram.md](engram.md) — Diferencia entre memoria persistente, bootstrap y skill-registry
+- [docs/sdd.md](sdd.md) — Desarrollo Guiado por Especificaciones (SDD) y sdd-orchestrator

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -1,0 +1,94 @@
+# Desarrollo Guiado por Especificaciones (SDD)
+
+Este documento explica qué es el Desarrollo Guiado por Especificaciones (**SDD**, por sus siglas en inglés: *Spec-Driven Development*) y cómo se utiliza el **orquestador sdd-orchestrator** en este repositorio.
+
+## ¿Qué es SDD?
+
+El **Desarrollo Guiado por Especificaciones (SDD)** es un enfoque de trabajo estructurado que separa el *qué* (especificaciones) del *cómo* (implementación). En lugar de saltar directo al código, SDD guía el desarrollo a través de fases documentadas:
+
+```text
+Exploración → Propuesta → Especificaciones → Diseño → Tareas → Implementación → Verificación → Archivado
+```
+
+### Beneficios principales
+
+- **Claridad antes del código**: Define qué se va a construir antes de decidir cómo hacerlo
+- **Trazabilidad**: Cada cambio tiene una justificación documentada
+- **Revisiones estructuradas**: Los cambios pasan por verificación contra especificaciones
+- **Memoria persistente**: Las decisiones y el contexto se guardan para sesiones futuras
+
+## Fases del SDD
+
+| Fase | Propósito |
+|------|-----------|
+| **sdd-explore** | Investigar ideas y explorar el código antes de comprometerse con un cambio |
+| **sdd-propose** | Crear una propuesta con intención, alcance y enfoque |
+| **sdd-spec** | Escribir especificaciones con requisitos y escenarios |
+| **sdd-design** | Crear documento de diseño técnico con decisiones de arquitectura |
+| **sdd-tasks** | Desglosar un cambio en una lista de tareas de implementación |
+| **sdd-apply** | Implementar tareas siguiendo las especificaciones y el diseño |
+| **sdd-verify** | Validar que la implementación coincide con especificaciones, diseño y tareas |
+| **sdd-archive** | Sincronizar especificaciones y archivar un cambio completado |
+
+## El Orquestador sdd-orchestrator
+
+El **sdd-orchestrator** es el coordinador de flujos SDD. Es un agente que:
+
+- **No ejecuta código directamente**: Delega todo el trabajo real a sub-agentes especializados
+- **Mantiene el hilo de conversación**: Coordina las fases y sintetiza resultados
+- **Carga habilidades automáticamente**: Resuelve qué habilidades del proyecto aplican según el contexto
+- **Gestiona el almacenamiento**: Decide dónde persistir los artefactos (Engram, archivos, o ambos)
+
+### Comandos Disponibles
+
+| Comando | Descripción |
+|---------|--------------|
+| `/sdd-init` | Inicializa el contexto SDD en un proyecto |
+| `/sdd-explore <tema>` | Investiga una idea sin crear archivos |
+| `/sdd-apply [cambio]` | Implementa tareas en lotes |
+| `/sdd-verify [cambio]` | Valida implementación contra especificaciones |
+| `/sdd-archive [cambio]` | Cierra un cambio y persiste el estado final |
+| `/sdd-onboard` | Recorrido guiado de SDD usando el código base real |
+
+### Modos de Ejecución
+
+- **Automático (`auto`)**: Ejecuta todas las fases seguidas sin pausas
+- **Interactivo (`interactive`)**: Muestra el resultado después de cada fase y permite ajustes
+
+## Uso en Este Repositorio
+
+Este repositorio utiliza SDD para cambios sustanciales en la documentación y estructura. El flujo típico es:
+
+1. **Inicialización**: `/sdd-init` detecta el stack, convenciones y capacidades de prueba
+2. **Nuevo cambio**: `/sdd-new <cambio>` inicia exploración y propuesta
+3. **Continuación**: `/sdd-continue [cambio]` ejecuta la siguiente fase dependiente
+4. **Implementación**: `/sdd-apply [cambio]` aplica las tareas documentadas
+
+### Almacenamiento de Artefactos
+
+Los artefactos SDD pueden guardarse en:
+
+- **Engram** (por defecto): Memoria persistente rápida, sin archivos locales
+- **OpenSpec**: Archivos en `openspec/` con historial git completo
+- **Híbrido**: Ambos — archivos para compartir + Engram para recuperación
+
+## Relación con el Pipeline de Producto
+
+SDD complementa el pipeline de producto de este repositorio:
+
+```text
+Idea → brainstorming → descubrimiento → inicio proyecto → factibilidad técnica
+              ↓
+         (SDD inicia aquí para cambios de arquitectura/documentación)
+              ↓
+         sdd-init → sdd-new → sdd-apply → sdd-verify → repo-bootstrap → Desarrollo
+```
+
+---
+
+## Notas Importantes
+
+- **SDD es para cambios sustanciales**: No se requiere para ajustes menores de documentación
+- **Las especificaciones son el criterio de aceptación**: La implementación se valida contra ellas
+- **La memoria persistente (Engram) es clave**: Permite recuperar contexto entre sesiones de trabajo
+- **El orquestador no es un ejecutor**: Coordina, no escribe código directamente

--- a/project-init/README.md
+++ b/project-init/README.md
@@ -1,8 +1,8 @@
-# Project Init — Skill de Transición
+# Project Init — Habilidad de Transición
 
 ## Qué hace
 
-Esta skill cierra la brecha entre `product-discovery` y `tech-feasibility`, transformando los hallazgos de discovery en un plan ejecutable para desarrollo técnico.
+Esta habilidad cierra la brecha entre `product-discovery` y `tech-feasibility`, transformando los hallazgos de descubrimiento en un plan ejecutable para desarrollo técnico.
 
 ## Output Principal
 
@@ -11,32 +11,31 @@ Esta skill cierra la brecha entre `product-discovery` y `tech-feasibility`, tran
 
 ## Documentación Completa
 
-Ver [SKILL.md](SKILL.md) para la especificación detallada de la fase, procesos, handoffs y casos de uso.
+Ver [SKILL.md](SKILL.md) para la especificación detallada de la fase, procesos, transiciones de fase o entregas de control y casos de uso.
 
 ## Uso Rápido
 
 ### Pipeline completo (4 pasos)
 
 ```
-brainstorm → product-discovery → project-init → tech-feasibility
+brainstorming → descubrimiento de producto → inicio de proyecto → factibilidad técnica
 ```
 
-### Ruta ligera (bypass de project-init, 3 pasos)
+### Ruta ligera (omisión de inicio de proyecto, 3 pasos)
 
 ```
-brainstorm → product-discovery → tech-feasibility
+brainstorming → descubrimiento de producto → factibilidad técnica
 ```
 
-**Condiciones para bypass**:
+**Condiciones para la omisión**:
 - Proyecto personal con alcance muy pequeño (1-2 features)
 - El usuario es el único interesado y decisor
 - No hay restricciones regulatorias ni organizacionales
-- tech-feasibility puede funcionar con Discovery Report directo
+- factibilidad técnica puede funcionar con Discovery Report directo
 
 ## Archivos de Referencia
 
-- [SKILL.md](SKILL.md) — Especificación completa de la skill
-- [../docs/sdd-pmbok8-lite-alignment-spec.md](../docs/sdd-pmbok8-lite-alignment-spec.md) — Cambio completo (pmbok8-lite-alignment)
+- [SKILL.md](SKILL.md) — Especificación completa de la habilidad
 
 ## Output Esperado
 
@@ -45,7 +44,7 @@ brainstorm → product-discovery → tech-feasibility
 
 ## Notas
 
-- **Sin implementación técnica**: Esta skill solo produce documentación y acuerdos
+- **Sin implementación técnica**: Esta habilidad solo produce documentación y acuerdos
 - **Enfoque PMBOK 8 Lite**: Mínimo indispensable, nada de burocracia pesada
-- **Compatible con side projects**: Diseñada para no añadir overhead innecesario
+- **Compatible con proyectos personales**: Diseñada para no añadir carga operativa innecesaria
 - **Project Charter**: Solo como alias temporal; el nombre canónico es Project Framing Doc


### PR DESCRIPTION
Closes #35

## Summary
- Clarify the public docs in Spanish-first language and explain key concepts like SDD, Engram, and `sdd-orchestrator` more explicitly.
- Add `docs/sdd.md`, improve `docs/engram.md` and `docs/installation.md`, and clean public wording in `project-init/README.md`.
- Document that the official Supabase and Firebase skills were sourced through Skills.sh and keep acknowledgements professional.

## Changes Table
| File | Change |
|------|--------|
| `README.md` | Clarified repo purpose, reduced Spanglish, and improved public acknowledgements |
| `docs/sdd.md` | Added a public explanation of SDD and `sdd-orchestrator` |
| `docs/engram.md` | Reframed Engram with a human-first explanation and cleaner Spanish wording |
| `docs/README.md` | Improved navigation and public orientation |
| `docs/installation.md` | Clarified Skills.sh usage and origin of official Supabase/Firebase skills |
| `project-init/README.md` | Removed or translated residual English wording and public references not desired |

## Test Plan
- [x] Manually reviewed the affected docs for clarity and Spanish-first wording
- [x] Verified public docs no longer expose historical SDD artifacts
- [x] Confirmed links and conceptual hierarchy during SDD verify

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant validation for the changed files
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No Co-Authored-By trailers