### PR TITLE
feat(skills): add derived workflow helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Idea → brainstorming → descubrimiento de producto → factibilidad técnica 
 |-----------|-----------|
 | **dev-skills/flutter-personal-standards** | Criterio personal para Flutter |
 | **dev-skills/repo-bootstrap** | Prepara el repositorio: flujo de PR, release-please, estándares |
+| **dev-skills/repo-guardrails** | Advisory/warning-first sobre ramas, PRs y commits (capa lateral) |
+| **dev-skills/sdd-to-issues** | Export-only: convierte artifacts SDD en issues GitHub |
+| **dev-skills/request-triage** | Enrutador opt-in que decide a dónde va un request |
+| **dev-skills/clarify-with-artifacts** | Estructura contexto usando artifacts existentes (opt-in) |
 
 ### 3. Habilidades especializadas (requieren tecnología confirmada)
 
@@ -132,6 +136,7 @@ Si quieres la mejor experiencia: [Gentle AI Repository](https://github.com/Gentl
 Este proyecto utiliza herramientas y referentes que han contribuido a su desarrollo:
 
 - **[Gentleman-Programming/gentle-ai](https://github.com/Gentleman-Programming/gentle-ai)**: Por el entorno de trabajo, la filosofía de desarrollo y las herramientas que permitieron revisar, corregir y refinar este repositorio.
+- **[mattpocock/skills](https://github.com/mattpocock/skills)**: Por servir como referencia e inspiración para varias habilidades adaptadas a este ecosistema, especialmente en utilidades tácticas de arquitectura, diagnóstico y flujo de trabajo.
 - **Supabase**: Por sus habilidades oficiales que extienden las capacidades de este repositorio.
 - **Firebase**: Por sus habilidades oficiales que cubren casos de uso específicos en la plataforma.
 - **Equipo de opencode**: Por la plataforma que hace posible la ejecución de estas habilidades.

--- a/dev-skills/clarify-with-artifacts/SKILL.md
+++ b/dev-skills/clarify-with-artifacts/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: clarify-with-artifacts
+description: >
+  Helper opt-in que estructura la intención del usuario usando artifacts existentes
+  (docs, Engram, proposal, spec, explore). NO sustituye sdd-propose ni sdd-spec;
+  output mínimo inline o checklist para alimentar SDD.
+license: Apache-2.0
+metadata:
+  author: KkapsCa
+  version: "1.0"
+  pipeline: "project-kickstart/core"
+---
+
+# Clarify with Artifacts — Opt-in Context Helper
+
+> **Input:** prompt del usuario + docs/Engram/proposal/spec/explore existentes
+> **Output:** resumen inline o checklist para alimentar proposal/spec
+> **Modo:** opt-in, output mínimo, NO reemplaza SDD
+
+---
+
+## When to Use
+
+Usa esta skill cuando:
+- el usuario tenga una idea vaga y ya existan docs/artifacts relevantes,
+- quieras estructurar contexto rápidamente antes de `sdd-propose` o `sdd-spec`,
+- necesites un resumen breve que recoja lo que ya se sabe del proyecto.
+
+## When NOT to Use
+
+- el usuario ya esté en fase SDD (`/sdd-*`) — usa la fase correspondiente,
+- busques escribir artifacts canónicos (usa `sdd-propose` / `sdd-spec`),
+- el request sea puramente técnico de stack (usa skill de stack),
+- no existan artifacts previos y la idea sea muy temprana (usa `brainstorm`).
+
+---
+
+## Principio Rector
+
+**No reemplaza SDD.** Esta skill es un puente ligero que junta lo que ya se sabe (docs, Engram, explore) para que el usuario entre a `sdd-propose` o `sdd-spec` con más contexto. Nunca genera artifacts fuente de verdad.
+
+---
+
+## Fuentes que Consulta
+
+| Fuente | Qué aporta |
+|--------|------------|
+| `docs/` | Estándares, governance, SDD docs |
+| Engram (`mem_search`) | Decisiones, discoveries, session summaries previos |
+| `sdd/{change}/explore` | Hallazgos de exploración previa |
+| `sdd/{change}/proposal` | Intención y scope ya delineados |
+| `.atl/skill-registry.md` | Triggers y reglas de routing actuales |
+
+---
+
+## Output Esperado
+
+Una de estas dos opciones (la más ligera posible):
+
+**1. Resumen inline breve:**
+```text
+📋 Clarify Summary:
+- Proyecto: KkapsCa-project-kickstart
+- Stack confirmado: Flutter + Supabase (ver tech-feasibility)
+- Intención: Adaptar 4 skills derivadas de matt
+- Artifacts previos: proposal ✅, spec ✅, design ✅, tasks ✅
+- Siguiente paso sugerido: sdd-apply
+```
+
+**2. Checklist de entrada para SDD:**
+```markdown
+## Checklist para sdd-propose
+- [ ] Problema claro: {resumen}
+- [ ] Usuario identificado: {quién}
+- [ ] Propuesta de valor: {qué aporta}
+- [ ] MVP definido: {alcance mínimo}
+```
+
+---
+
+## Qué NO hace esta skill
+
+- NO escribe artifacts canónicos (SDD manda en eso),
+- NO reemplaza `sdd-propose` ni `sdd-spec`,
+- NO aclara contenido profundo (para eso están las fases SDD),
+- NO es obligatoria: es opt-in y vive como helper lateral,
+- NO compite con `brainstorm` (ese es para ideas muy tempranas sin artifacts).
+
+---
+
+## Límite Estricto
+
+Esta skill puede leer y resumir, pero **NUNCA** debe:
+1. Crear un artifact con topic_key en Engram (eso es SDD),
+2. Sobrescribir proposal o spec existentes,
+3. Convertirse en un paso obligatorio del pipeline.
+
+---
+
+## Relación con Otras Skills
+
+| Skill | Relación |
+|--------|----------|
+| `sdd-propose` / `sdd-spec` | Aguas abajo; `clarify` alimenta, no reemplaza |
+| `request-triage` | `triage` decide destino; `clarify` estructura contenido |
+| `brainstorm` | Upstream; si no hay nada claro, usa `brainstorm` primero |
+| `explore` (SDD) | `explore` es fase SDD; `clarify` es helper opt-in previo |

--- a/dev-skills/diagnose/SKILL.md
+++ b/dev-skills/diagnose/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: diagnose
+description: >
+  Debugging sistemático para errores concretos. Usa el ciclo canónico
+  repro → minimiza → instrumenta → arregla → regresión.
+  Integra con SDD: úsalo antes de proponer cambios formales.
+  Trigger: Cuando el usuario diga "debug", "diagnosticar", "arreglar error",
+  "fix bug", "por qué falla", "reproducir bug", "regression check".
+license: Apache-2.0
+metadata:
+  author: KkapsCa
+  version: "1.0"
+---
+
+# Diagnose — Debugging Canónico
+
+**Companion Skill** — Debugging puntual (usa `improve-codebase-architecture` para review amplio).
+
+## When to Use
+
+Usa esta skill cuando:
+
+- haya un error concreto, crash o comportamiento inesperado,
+- el usuario pida "debug", "diagnosticar", "arreglar este error",
+- necesites aislar un bug antes de proponer un cambio en SDD,
+- quieras validar que un fix no rompió nada (regresión).
+
+## Trigger
+
+Cárgala al escuchar: "debug", "diagnosticar", "arreglar error", "fix bug", "por qué falla", "reproducir bug", "regression check" o cualquier variante que pida investigar un fallo específico.
+
+## When NOT to Use
+
+- para revisiones de arquitectura amplias (usa `improve-codebase-architecture`),
+- para planear features nuevas (usa `sdd-propose`),
+- para editing de flujo normal sin un bug claro,
+- **no usar para review arquitectónico amplio; para eso usa `improve-codebase-architecture`**.
+
+## Precedencia
+
+- Si el bug es puramente de framework (Flutter, Firebase, Supabase, Genkit), usar la skill oficial de stack en su lugar.
+- Esta skill es **companion** para debugging puntual; no compite con skills de stack específico.
+
+## Fallback
+
+- Si no hay error reproducible o el usuario está en fase de diseño/propuesta, no activar; usar `sdd-design` o `sdd-propose`.
+- Si la skill requerida no está instalada en `~/.config/opencode/skills`, documentar la brecha y seguir con SDD/skill disponible.
+- Si el problema resulta ser arquitectónico y no un bug puntual, enrutar a `improve-codebase-architecture`.
+
+---
+
+## Ciclo de Debugging (Canónico)
+
+```
+1. REPRO: reproducir el error de forma consistente.
+   - Anotar pasos exactos.
+   - Identificar entorno (OS, versión, stack).
+
+2. MINIMIZE: reducir el escenario al mínimo viable.
+   - Eliminar variables: ¿ocurre sin estado previo? ¿con datos mínimos?
+   - Aislar el componente/archivo sospechoso.
+
+3. INSTRUMENT: agregar observabilidad.
+   - Logs, prints, debugger, tests que fallen.
+   - Capturar el estado exacto en el punto de falla.
+
+4. FIX: aplicar la corrección mínima.
+   - No refactors grandes, solo lo necesario para que pase el caso.
+   - Mantener el fix proporcional al problema.
+
+5. REGRESSION: verificar que no rompió nada.
+   - Correr tests existentes.
+   - Si no hay tests, crear un caso mínimo que valide el fix.
+```
+
+---
+
+## Output Esperado
+
+Al terminar, entrega un reporte breve:
+
+```markdown
+# Diagnóstico — [Breve descripción del error]
+
+## Reproducción
+Pasos: [1, 2, 3]
+Entorno: [stack/versión]
+
+## Causa raíz
+[Qué lo provocó]
+
+## Fix aplicado
+[Archivo + qué cambió]
+
+## Regresión
+- [x] Tests existentes pasan
+- [x] Nuevo caso de validación agregado (o justificación de por qué no)
+```
+
+---
+
+## Integración con SDD
+
+- Esta skill es un **companion** para fases de SDD, no un proceso paralelo.
+- Si el bug revela una necesidad de cambio estructural, luego enruta a `sdd-propose` con este diagnóstico como base.
+- Si el fix requiere una feature o refactor amplio, no lo hagas aquí: documéntalo y propón el cambio vía SDD.
+
+---
+
+## PRE-FLIGHT CHECKLIST
+
+- [ ] Ya reproduje el error de forma consistente
+- [ ] Ya minimicé el escenario
+- [ ] Ya instrumenté para ver el estado interno
+- [ ] Ya apliqué el fix mínimo
+- [ ] Ya verifiqué regresión
+
+---
+
+## Reglas Operativas
+
+- **No refactors mientras debuggeas**: enfócate en arreglar el bug.
+- **No mixes con arquitectura**: si descubres deuda técnica, anótala para después.
+- **Output conciso**: no escribas un tratado, entrega el reporte y ya.
+- **Usa las herramientas de observabilidad del stack**: `print` en Dart, `log` en Go, `console.log` en JS, etc.
+
+---
+
+## Commands (reference)
+
+```bash
+# Correr tests rápidos (según stack)
+flutter test
+go test ./...
+npm test
+pytest
+```

--- a/dev-skills/improve-codebase-architecture/SKILL.md
+++ b/dev-skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: improve-codebase-architecture
+description: >
+  Revisión de arquitectura enfocada en detectar deuda, acoplamiento y violaciones
+  de responsabilidades. Integra con SDD como paso previo a propuestas o diseño.
+  Trigger: Cuando el usuario diga "revisar arquitectura", "architecture review",
+  "mejorar estructura", "codebase health", "tech debt check", "refactor review".
+license: Apache-2.0
+metadata:
+  author: KkapsCa
+  version: "1.0"
+---
+
+# Improve Codebase Architecture
+
+**Main Skill** — Revisión arquitectónica primaria (las otras dos son *companions*).
+
+## When to Use
+
+Usa esta skill cuando:
+
+- el usuario pida revisar la arquitectura de un proyecto o módulo,
+- haya sospecha de deuda técnica, acoplamiento excesivo o responsabilidades mezcladas,
+- se vaya a iniciar una propuesta (`sdd-propose`) o diseño (`sdd-design`) y necesites un diagnóstico previo,
+- quieras justificar un refactor antes de proponer cambios formales en SDD.
+
+## Trigger
+
+Cárgala cuando escuches: "revisar arquitectura", "architecture review", "mejorar estructura", "codebase health", "tech debt check", "refactor review", o cualquier variante que sugiera evaluar la salud estructural del código.
+
+## When NOT to Use
+
+- para correcciones pequeñas o fixes puntuales (usa `diagnose`),
+- cuando el problema sea específico de Flutter, Firebase o Supabase (usa la skill oficial correspondiente),
+- si el usuario apenas está en fase de `brainstorm` o `product-discovery` y no hay código que revisar,
+- **si hay un comando `/sdd-*` explícito (SDD manda, esta skill es solo complemento previo)**.
+
+## Precedencia
+
+- Si el problema es específico de un stack (Flutter, Firebase, Supabase, Genkit), usa la skill oficial de ese stack en lugar de esta.
+- Esta skill es **main skill** para revisión arquitectónica transversal; las skills de stack tienen prioridad si el problema es puramente de ese framework.
+
+## Fallback
+
+- Si no hay código suficiente para revisar (proyecto en fase `brainstorm`/`discovery`), no activar; usar la fase upstream correspondiente.
+- Si la skill requerida no está instalada en `~/.config/opencode/skills`, documentar la brecha y seguir con SDD/skill disponible.
+- Si el módulo ya es conocido y el cambio es mecánico, omitir esta skill.
+
+---
+
+## Core Patterns
+
+### 1. Enfoque proporcional
+- No impongas Clean Architecture completa a un proyecto de 2 pantallas.
+- Detecta si el tamaño del proyecto justifica capas separadas (`flutter-architecting-apps`) o si basta con separar responsabilidades básicas.
+
+### 2. Detecta anti-patrones
+- Lógica de negocio dentro de UI,
+- IO (HTTP, DB) en widgets o controladores de estado,
+- Estado global compartido innecesariamente,
+- Dependencias circulares o acoplamiento fuerte entre módulos.
+
+### 3. Archivo de salida (output)
+La revisión debe producir un resumen ejecutivo conciso:
+
+```markdown
+# Architecture Review — [Proyecto/Módulo]
+
+## Estado general
+[Bueno / Aceptable / Problemático] — [breve justificación]
+
+## Hallazgos clave
+- [Violación 1: dónde, qué, impacto]
+- [Violación 2: ...]
+
+## Recomendaciones
+- [Acción concreta, archivos sugeridos, prioridad]
+
+## Input para SDD
+- [Si aplica: qué propuesta/diseño debería hacerse tras este review]
+```
+
+### 4. Integración con SDD
+- Esta skill NO reemplaza `sdd-propose` ni `sdd-design`.
+- Es un paso previo que alimenta esas fases con contexto estructural.
+- Si el usuario quiere cambios formales después del review, enruta a `sdd-propose` con este output como base.
+
+---
+
+## Workflow (Architecture Review)
+
+```
+1. Leer estructura de directorios relevante (lib/, src/, internal/, etc.)
+2. Identificar responsabilidades por archivo/carpeta
+3. Detectar anti-patrones y deuda técnica
+4. Evaluar si la arquitectura es proporcional al alcance
+5. Producir el resumen ejecutivo (ver formato arriba)
+6. Sugerir próximos pasos (SDD propose/design o fixes puntuales)
+```
+
+---
+
+## Output Contract
+
+La skill termina cuando se entregó el resumen ejecutivo y se indicó claramente si el siguiente paso es:
+
+- `sdd-propose` (cambio formal),
+- fix puntual (usa `diagnose`),
+- o mantener y monitorear (si el estado es bueno).
+
+---
+
+## Diagnostics Integration
+
+Si durante la revisión encuentras un bug o comportamiento incorrecto, NO intentes arreglarlo aquí.
+- Documéntalo en la sección de hallazgos,
+- Luego usa `diagnose` para el fix puntual.
+
+---
+
+## PRE-FLIGHT CHECKLIST
+
+- [ ] Ya identifiqué la estructura general del proyecto
+- [ ] Ya detecté si hay capas separadas o todo está mezclado
+- [ ] Ya confirmé si la arquitectura es proporcional al alcance
+- [ ] Ya produje el resumen ejecutivo
+- [ ] Ya indiqué próximos pasos (SDD o fixes)
+
+---
+
+## Reglas Operativas
+
+- Mantén el tono directo y constructivo, no seas un manual de teoría.
+- Enfócate en lo que está mal y cómo arreglarlo, no en lo que está bien.
+- Si el proyecto no tiene arquitectura discernible, di "acoplado / sin estructura" y recomienda pasos mínimos.
+- No inventes reglas de Clean Architecture si el proyecto es pequeño.
+- Si aparece un concepto específico (Flutter, Firebase, Supabase), enruta a la skill oficial correspondiente.
+
+---
+
+## Commands (reference)
+
+```bash
+# Quick structure overview
+find lib -type f -name "*.dart" | head -20
+tree -L 3 src/ 2>/dev/null || find src -type d | head -20
+```

--- a/dev-skills/repo-guardrails/SKILL.md
+++ b/dev-skills/repo-guardrails/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: repo-guardrails
+description: >
+  Capa advisory/warning-first que revisa estado de ramas, PRs, labels y commits
+  antes de acciones git/gh. NO reemplaza repo-bootstrap ni bloquea nada.
+  Solo advierte basándose en reglas ya definidas en repo-bootstrap y docs/governance.md.
+license: Apache-2.0
+metadata:
+  author: KkapsCa
+  version: "1.0"
+  pipeline: "project-kickstart/dev-bootstrap"
+---
+
+# Repo Guardrails — Advisory-First Wrapper
+
+> **Input:** estado de rama, PR, labels, commits y reglas de `repo-bootstrap` / `docs/governance.md`
+> **Output:** warnings/checklist inline; NO bloquea ni reemplaza `repo-bootstrap`
+
+---
+
+## When to Use
+
+Usa esta skill cuando:
+- el usuario esté por hacer push, crear PR o mergear,
+- quieras una revisión rápida de cumplimiento antes de ejecutar,
+- necesites recordatorios sobre convenciones del repo sin imponer nuevas reglas.
+
+## When NOT to Use
+
+- ya estés ejecutando `repo-bootstrap` (esa skill manda en normas),
+- el usuario esté en flujo SDD (`/sdd-*`) — usa la fase correspondiente,
+- busques bloquear acciones: esta skill SOLO advierte, no bloquea.
+
+---
+
+## Principio Rector
+
+**Warning-first, never blocking.** Esta skill es una capa lateral que operacionaliza las reglas de `repo-bootstrap` y `docs/governance.md`, pero no añade nuevas reglas ni reemplaza el flujo normativo.
+
+---
+
+## Checklist de Guardrails (Advisory)
+
+Antes de push / PR / merge, revisa:
+
+| Ítem | Qué verificar | Warning si... |
+|-------|---------------|---------------|
+| Rama | ¿Es `main`, `master` o `release`? | Push directo a rama protegida |
+| PR | ¿Existe PR abierto para la rama? | Push sin PR abierto |
+| Conventional Commits | ¿Los commits siguen formato `type(scope): message`? | Commits sin formato convencional |
+| Labels | ¿Tiene labels apropiados para el tipo de cambio? | PR sin labels después de 2h abierto |
+| Checks | ¿Passing? | Checks fallando o pendientes |
+| PR template | ¿Llenó la descripción? | PR vacío o con template sin tocar |
+
+---
+
+## Qué NO hace esta skill
+
+- NO bloquea pushes ni PRs (eso lo hace `repo-bootstrap` vía hook `pre-push` y branch protection)
+- NO escribe nuevas reglas (usa las de `docs/governance.md`)
+- NO reemplaza `issue-creation` ni `branch-pr`
+- NO crea artifacts canónicos nuevos
+
+---
+
+## Output Esperado
+
+Una lista inline de warnings, ejemplo:
+
+```
+⚠️ Guardrails Check:
+- [WARN] Push directo a main detectado → usa rama feature
+- [WARN] No se encontró PR abierto para feat/mi-cambio
+- [OK] Conventional commit detectado: feat(core): add flow
+```
+
+---
+
+## Relación con Otras Skills
+
+| Skill | Relación |
+|--------|----------|
+| `repo-bootstrap` | Manda en normas; `repo-guardrails` solo lee sus reglas |
+| `branch-pr` | `repo-guardrails` advierte antes de que abras PR |
+| `issue-creation` | No se solapan; `repo-guardrails` no crea issues |
+
+---
+
+## Referencia
+
+Las reglas que esta skill revisa viven en:
+- `docs/governance.md` — estándares del repo
+- `dev-skills/repo-bootstrap/SKILL.md` — definición normativa
+- `.github/PULL_REQUEST_TEMPLATE.md` — checklist de PR

--- a/dev-skills/request-triage/SKILL.md
+++ b/dev-skills/request-triage/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: request-triage
+description: >
+  Enrutador opt-in y ultra-delgado que decide si un request va a SDD, a una skill existente
+  o a issue/discussion. NO aclara contenido ni parte trabajo; solo decide el destino.
+license: Apache-2.0
+metadata:
+  author: KkapsCa
+  version: "1.0"
+  pipeline: "project-kickstart/core"
+---
+
+# Request Triage — Ultra-Thin Router
+
+> **Input:** prompt del usuario, `.atl/skill-registry.md`, Engram reciente
+> **Output:** recomendación inline (ej. "ve a sdd-propose", "usa Flutter skill", "crea issue")
+> **Modo:** opt-in, solo enrutamiento
+
+---
+
+## When to Use
+
+Usa esta skill cuando:
+- el usuario haga una pregunta ambigua sobre qué hacer a continuación,
+- exista duda entre usar SDD, una skill específica o crear un issue,
+- quieras una recomendación rápida sin entrar en aclaración de contenido.
+
+## When NOT to Use
+
+- el usuario ya haya dado un comando `/sdd-*` explícito (gana SDD, no enrutes),
+- el contexto sea puramente técnico de stack (usa skill de stack correspondiente),
+- busques aclarar o estructurar el contenido del request (usa `clarify-with-artifacts`),
+- quieras partir trabajo (usa `sdd-tasks` o `sdd-to-issues`).
+
+---
+
+## Principio Rector
+
+**Ultra-delgado, solo router.** Esta skill es un semáforo, no un taller. Decide el destino y se detiene. No aclara, no implementa, no parte trabajo.
+
+---
+
+## Lógica de Enrutamiento
+
+```text
+Request llega
+      │
+      ▼
+¿Comando /sdd-* explícito?
+      ├─ SÍ → Redirigir a fase SDD correspondiente (STOP)
+      │
+      ▼ NO
+¿Es pregunta técnica de stack (Flutter/Firebase/Supabase/Genkit)?
+      ├─ SÍ → Usar skill de stack correspondiente (STOP)
+      │
+      ▼ NO
+¿Hay artifact SDD previo relevante en Engram?
+      ├─ SÍ → Sugerir continuar con SDD (sdd-continue / sdd-verify)
+      │
+      ▼ NO
+¿El request implica una tarea nueva?
+      ├─ SÍ → Sugerir `sdd-new` o `issue-creation`
+      │
+      ▼ NO
+→ Sugerir discussion / clarification
+```
+
+---
+
+## Ejemplos de Output
+
+| Request | Recomendación |
+|---------|---------------|
+| "Quiero añadir auth" | Ve a SDD: `/sdd-new auth-feature` |
+| "Arregla el bug en login" | Usa `diagnose` o crea issue vía `issue-creation` |
+| `/sdd-apply auth-feature` | Comando SDD explícito → ejecutar `sdd-apply` directamente |
+| "¿Qué stack elijo para mi app?" | Usa `tech-feasibility` |
+| "Quiero reportar un error" | Usa `issue-creation` para crear bug report |
+
+---
+
+## Qué NO hace esta skill
+
+- NO aclara el contenido del request (eso es `clarify-with-artifacts`),
+- NO parte trabajo en tareas (eso es `sdd-tasks`),
+- NO escribe artifacts canónicos (ni en Engram ni archivos),
+- NO reemplaza fases SDD ni skills de stack,
+- NO es obligatoria: es opt-in y vive como helper lateral.
+
+---
+
+## Nota de Persistencia
+
+Opcionalmente puede dejar una nota breve en Engram (`mem_save`) con la recomendación dada, pero **NUNCA** escribe artifacts canónicos. El destino final (SDD, issue, discussion) es quien persiste.
+
+---
+
+## Relación con Otras Skills
+
+| Skill | Relación |
+|--------|----------|
+| `sdd-*` (todas) | Ganan si hay comando explícito; `request-triage` cede |
+| `clarify-with-artifacts` | `request-triage` decide destino; `clarify` estructura contenido |
+| `issue-creation` | Canal de salida si se decide crear issue |
+| Skills de stack | Ganan si el request es técnico específico de ese stack |

--- a/dev-skills/sdd-to-issues/SKILL.md
+++ b/dev-skills/sdd-to-issues/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: sdd-to-issues
+description: >
+  Export-only skill que convierte artifacts SDD (spec, design, tasks) en issue drafts
+  o issues GitHub reales usando issue-creation. NO descompone trabajo; eso lo hace sdd-tasks.
+license: Apache-2.0
+metadata:
+  author: KkapsCa
+  version: "1.0"
+  pipeline: "project-kickstart/sdd"
+---
+
+# SDD-to-Issues — Export-Only Wrapper
+
+> **Input:** `sdd/{change}/spec`, `design`, `tasks` desde Engram (o `openspec/` si aplica)
+> **Output:** issue drafts o issues GitHub vía `issue-creation`
+> **Modo:** Export-only; NO particiona trabajo
+
+---
+
+## When to Use
+
+Usa esta skill cuando:
+- ya exista un cambio SDD con spec/design/tasks aprobados,
+- el usuario pida "exportar a issues" o "crear issues desde SDD",
+- necesites pasar el plan SDD al sistema de issues sin reescribir nada.
+
+## When NOT to Use
+
+- estés en fase de propuesta o diseño (usa `sdd-propose` / `sdd-design`),
+- busques partir el trabajo en tareas (usa `sdd-tasks` — eso es su territorio),
+- no existan artifacts SDD previos (sin artifacts → no genera nada),
+- el usuario pida crear issues desde cero (usa `issue-creation` directamente).
+
+---
+
+## Principio Rector
+
+**Export-only.** Esta skill lee artifacts SDD ya aprobados y los traduce a issues; no decide qué hacer, no parte trabajo, no valida contenido. La partición de trabajo es responsabilidad exclusiva de `sdd-tasks`.
+
+---
+
+## Flujo de Exportación
+
+```
+1. Leer artifacts SDD
+   └── spec → contexto del cambio
+   └── design → decisiones técnicas
+   └── tasks → checklists de implementación
+
+2. Mapear a issue draft
+   └── Título: basado en proposal/spec
+   └── Body: resumen de design + tasks como checklist
+   └── Labels: según tipo de cambio (feat, fix, chore)
+
+3. Crear issue vía issue-creation
+   └── NO usa gh manualmente; delega a issue-creation
+```
+
+---
+
+## Qué NO hace esta skill
+
+- NO descompone trabajo en tareas (eso es `sdd-tasks`)
+- NO escribe artifacts canónicos nuevos
+- NO reemplaza `sdd-tasks`, `sdd-spec` ni `sdd-design`
+- NO corre cuando no hay artifacts SDD que leer
+- NO compite con `issue-creation` / `branch-pr` para crear/aprobar issues y PRs
+
+---
+
+## Formato de Issue Generado
+
+```markdown
+## Summary
+{Basado en spec → qué se está haciendo y por qué}
+
+## Technical Approach
+{Basado en design → cómo se hará}
+
+## Tasks
+- [ ] {task 1.1}
+- [ ] {task 1.2}
+...
+
+## Acceptance Criteria
+{Basado en spec scenarios}
+```
+
+---
+
+## Fallback
+
+Si no hay artifacts SDD disponibles (`sdd/{change}/*` no encontrado en Engram o `openspec/`):
+- NO inventes contenido,
+- responde: "No se encontraron artifacts SDD para este cambio. Usa SDD primero o `issue-creation` para crear el issue manualmente."
+
+---
+
+## Relación con Otras Skills
+
+| Skill | Relación |
+|--------|----------|
+| `sdd-tasks` | Manda en partición de trabajo; `sdd-to-issues` solo exporta |
+| `issue-creation` | Canal de creación de issues; `sdd-to-issues` lo invoca |
+| `branch-pr` | NO se solapan; `sdd-to-issues` no abre PRs |
+| `sdd-propose` / `sdd-spec` | Upstream; `sdd-to-issues` vive downstream |
+
+---
+
+## Comandos
+
+### Exportar un cambio SDD a issue
+
+```
+Cargar sdd-to-issues → leer sdd/{change}/spec + design + tasks → generar issue draft → crear vía issue-creation
+```
+
+### Si no hay artifacts
+
+```
+Cargar sdd-to-issues → fallback: "No se encontraron artifacts SDD. Usa SDD primero."
+```

--- a/dev-skills/zoom-out/SKILL.md
+++ b/dev-skills/zoom-out/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: zoom-out
+description: >
+  Da una perspectiva de sistema antes de tocar código poco familiar.
+  Mapea dependencias, flujos y riesgos para evitar romper cosas al editar.
+  Integra con SDD: úsalo antes de `sdd-apply` o `sdd-design` en código desconocido.
+  Trigger: Cuando el usuario diga "entender el sistema", "zoom out",
+  "perspectiva global", "antes de editar esto", "entender flujo completo",
+  "system map", "dependency check".
+license: Apache-2.0
+metadata:
+  author: KkapsCa
+  version: "1.0"
+---
+
+# Zoom Out — Perspectiva de Sistema
+
+**Companion Skill** — Contexto previo a edición (usa `improve-codebase-architecture` para review amplio).
+
+## When to Use
+
+Usa esta skill cuando:
+
+- vayas a editar código que no conoces bien,
+- necesites entender cómo encaja una pieza en el sistema antes de proponer cambios,
+- el usuario pida "entender el sistema", "zoom out", "perspectiva global",
+- estés a punto de ejecutar `sdd-apply` en un módulo desconocido.
+
+## Trigger
+
+Cárgala al escuchar: "entender el sistema", "zoom out", "perspectiva global", "antes de editar esto", "entender flujo completo", "system map", "dependency check" o cualquier variante que pida ver el panorama completo antes de tocar código.
+
+## When NOT to Use
+
+- para debugging puntual (usa `diagnose`),
+- para revisión de arquitectura amplia (usa `improve-codebase-architecture`),
+- cuando ya conoces bien el módulo y no hay riesgo de efectos colaterales,
+- **no usar para debugging (usa `diagnose`) ni para review profundo (usa `improve-codebase-architecture`)**.
+
+## Precedencia
+
+- Omitir si el módulo ya es conocido o el cambio es mecánico.
+- Esta skill es **companion** para contexto previo a edición; no compite con skills de stack específico.
+
+## Fallback
+
+- Si no hay código suficiente o el usuario apenas inicia, no activar; usar fases upstream (`brainstorm`, `product-discovery`).
+- Si la skill no está instalada en `~/.config/opencode/skills`, documentar la brecha y seguir con SDD/skill disponible.
+- Si el módulo es conocido, omitir esta skill y proceder directo a `sdd-apply`.
+
+---
+
+## Paso de Perspectiva de Sistema
+
+Antes de editar código desconocido, ejecuta este proceso:
+
+```
+1. MAPA DE DEPENDENCIAS
+   - ¿Qué importa este archivo?
+   - ¿Qué otros archivos dependen de él?
+   - ¿Qué servicios, repositorios o APIs externas toca?
+
+2. FLUJO DE DATOS
+   - ¿De dónde entra la información?
+   - ¿Cómo se transforma antes de llegar aquí?
+   - ¿Qué efectos secundarios tiene (logs, DB, red)?
+
+3. RIESGOS IDENTIFICADOS
+   - ¿Qué podría romperse si cambio la firma de esta función?
+   - ¿Hay tests que cubran este flujo?
+   - ¿Hay otros módulos que asuman el comportamiento actual?
+```
+
+---
+
+## Output Esperado
+
+Entrega un resumen súper breve:
+
+```markdown
+# System Zoom — [Módulo/Archivo]
+
+## Dependencias clave
+- [Archivo/Api 1]
+- [Archivo/Api 2]
+
+## Flujo de datos
+Entrada: [de dónde]
+Salida: [a dónde]
+Efectos: [logs, DB, red]
+
+## Riesgos al editar
+- [Riesgo 1: qué podría romperse]
+- [Riesgo 2: ...]
+
+## Recomendación
+[Editar con cuidado / Hacer refactor previo / Está seguro modificar]
+```
+
+---
+
+## Integración con SDD
+
+- Esta skill es **companion** para `sdd-apply` y `sdd-design`.
+- Úsala **antes** de escribir código en módulos que no dominas.
+- No reemplaza el análisis de `sdd-design`, solo da contexto previo.
+- Si el mapa revela que el módulo necesita refactor, considera `improve-codebase-architecture` primero.
+
+---
+
+## PRE-FLIGHT CHECKLIST
+
+- [ ] Ya identifiqué las dependencias directas del archivo/módulo
+- [ ] Ya trazé el flujo de datos de entrada a salida
+- [ ] Ya listé los riesgos potenciales al editar
+- [ ] Ya entregué el resumen breve
+- [ ] Ya indicué si es seguro editar o requiere pasos previos
+
+---
+
+## Reglas Operativas
+
+- **Super breve**: no escribas un tratado, el resumen debe caber en una pantalla.
+- **No hagas cambios aquí**: solo mapa y diagnóstico de riesgos.
+- **Enfócate en efectos colaterales**: el objetivo es no romper nada al editar.
+- **Usa herramientas del stack**: `grep -r "import" lib/`, `go list -m all`, etc.
+
+---
+
+## Commands (reference)
+
+```bash
+# Ver imports de un archivo (Dart)
+grep -R "^import" lib/features/my_feature/
+
+# Ver dependencias de un paquete (Node)
+npm list --depth=1
+
+# Ver módulos que usan un paquete (Go)
+grep -r "mi_paquete" .
+```

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -54,6 +54,22 @@ Regla de oro: **No seas ese wey que hace push directo a main** 😤
 7. Al mergear Release PR → tag + release
 ```
 
+## Repo Guardrails (Capa Advisory)
+
+Este repositorio cuenta con la skill `repo-guardrails` como capa **advisory/warning-first** que revisa el estado de ramas, PRs, labels y commits antes de acciones críticas.
+
+**Nota importante**: `repo-guardrails` NO bloquea nada; es una ayuda visual que opera sobre las reglas definidas en este documento y en `dev-skills/repo-bootstrap/SKILL.md`. Las reglas normativas y el bloqueo real los impone `repo-bootstrap` vía hook `pre-push` y branch protection.
+
+Antes de push / PR / merge, `repo-guardrails` revisa:
+- Push directo a `main`, `master` o `release`
+- Existencia de PR abierto para la rama
+- Formato Conventional Commits
+- Labels apropiados en el PR
+- Checks pasando
+- Plantilla de PR llenada
+
+---
+
 ## Conventional Commits
 
 Todos los commits deben seguir el estándar [Conventional Commits](https://www.conventionalcommits.org/):

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -30,6 +30,22 @@ Exploración → Propuesta → Especificaciones → Diseño → Tareas → Imple
 | **sdd-verify** | Validar que la implementación coincide con especificaciones, diseño y tareas |
 | **sdd-archive** | Sincronizar especificaciones y archivar un cambio completado |
 
+### Helpers Opcionales (alrededor de SDD)
+
+Estas skills son **opt-in** y no reemplazan el flujo SDD principal. Viven como capa lateral:
+
+```text
+request → request-triage? → clarify-with-artifacts? → sdd-propose/spec/design/tasks → sdd-to-issues? → issue-creation / branch-pr
+```
+
+| Skill | Rol | Relación con SDD |
+|-------|-----|-------------------|
+| `request-triage` | Enrutador ultra-delgado que decide si el request va a SDD, a una skill existente o a issue/discussion | Solo decide destino; NO aclara contenido ni parte trabajo |
+| `clarify-with-artifacts` | Estructura contexto usando artifacts existentes (docs, Engram, proposal, spec) | Output mínimo inline; NO sustituye `sdd-propose`/`sdd-spec` |
+| `sdd-to-issues` | Exporta artifacts SDD (spec/design/tasks) a issue drafts o issues GitHub | Export-only; NO descompone trabajo (eso es `sdd-tasks`) |
+
+**Precedencia**: Comando `/sdd-*` explícito siempre gana sobre `request-triage` y `clarify-with-artifacts`. `sdd-tasks` gana sobre `sdd-to-issues` para partición de trabajo.
+
 ## El Orquestador sdd-orchestrator
 
 El **sdd-orchestrator** es el coordinador de flujos SDD. Es un agente que:


### PR DESCRIPTION
Closes #37

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- agrega 7 skills nuevas para review arquitectónico, debugging, contexto, guardrails y helpers derivados de workflow
- endurece el skill registry y documenta la convivencia de helpers opcionales con SDD
- reconoce a `mattpocock/skills` como referencia de inspiración para las adaptaciones tácticas

## Changes Table
| File | Change |
|------|--------|
| `dev-skills/improve-codebase-architecture/SKILL.md` | Añade la skill principal de review arquitectónico |
| `dev-skills/diagnose/SKILL.md` | Añade companion skill para debugging puntual |
| `dev-skills/zoom-out/SKILL.md` | Añade companion skill para contexto previo a edición |
| `dev-skills/repo-guardrails/SKILL.md` | Añade wrapper advisory-first alineado a `repo-bootstrap` |
| `dev-skills/sdd-to-issues/SKILL.md` | Añade exportador opcional desde artifacts SDD a issues |
| `dev-skills/request-triage/SKILL.md` | Añade router opt-in ultra-delgado |
| `dev-skills/clarify-with-artifacts/SKILL.md` | Añade helper opt-in para resumir artifacts existentes |
| `.atl/skill-registry.md` | Endurece routing, precedencia, fallback y anti-solape |
| `README.md` | Documenta las nuevas skills y agrega agradecimiento a `mattpocock/skills` |
| `docs/governance.md` | Documenta `repo-guardrails` como capa advisory |
| `docs/sdd.md` | Documenta helpers opcionales alrededor de SDD |

## Test Plan
- [x] Verificación documental/estructural completada vía SDD (`sdd-verify`) en Engram
- [x] Skills nuevas y docs quedaron consistentes con registry, precedencia y anti-solape
- [x] No se modificaron scripts ni flujo de build; `shellcheck` no aplica a este cambio

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (N/A, no scripts modified)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers