### PR TITLE
chore(ci): use release token and trim Genkit public docs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Idea → brainstorming → descubrimiento de producto → factibilidad técnica 
 
 ### 3. Habilidades especializadas (requieren tecnología confirmada)
 
-Las habilidades de **Supabase**, **Firebase** y **Genkit** se activan tras decidir la tecnología en `tech-feasibility`. Deben instalarse vía bootstrap para que opencode las detecte.
+Las habilidades de **Supabase** y **Firebase** se activan tras decidir la tecnología en `tech-feasibility`. Deben instalarse vía bootstrap para que opencode las detecte.
 
 Consulta la [guía de instalación](docs/installation.md) para disponibilidad real y `docs/engram.md` para entender cómo se separan inicialización, memoria persistente y orquestación.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,7 +45,7 @@ Ventaja: las habilidades son independientes del repositorio original.
 
 ---
 
-## Habilidades Externas (Supabase, Firebase, Genkit)
+## Habilidades Externas (Supabase y Firebase)
 
 Las habilidades de **Supabase** y **Firebase** provienen de las habilidades oficiales creadas por las respectivas plataformas. En este repositorio se integran para usarlas bajo el flujo de **Skills.sh**. Residen en una carpeta externa (por defecto `~/.agents/skills/`). El bootstrap las procesa automáticamente:
 
@@ -60,7 +60,6 @@ bash scripts/bootstrap.sh
 |------------|-----------|----------------|
 | **Supabase** | `supabase`, `supabase-postgres-best-practices` | Habilidades oficiales de Supabase adaptadas para el flujo de Skills.sh |
 | **Firebase** | `firebase-*` (10 habilidades) | Habilidades oficiales de Firebase adaptadas para el flujo de Skills.sh |
-| **Genkit** | `developing-genkit-*` | Habilidades oficiales de Genkit adaptadas para el flujo de Skills.sh |
 
 ### Rutas configurables
 
@@ -134,7 +133,6 @@ Este repositorio usa un registro interno de habilidades para definir **orquestac
 | `firebase-security-rules-auditor` | Para revisar/endurecer Security Rules | ✅ Sí + reglas concretas |
 | `firebase-data-connect` | Para Data Connect/SQL Connect/GraphQL/Postgres | ✅ Sí + contexto SQL/GraphQL |
 | `firebase-ai-logic-basics` | Para Firebase AI Logic/Gemini desde cliente | ✅ Sí + contexto de IA |
-| `developing-genkit-js` | Para Genkit en JS/TS | ✅ Sí + stack JS/TS |
 
 > **Importante**: No activar habilidades Firebase solo por mencionar Firebase. Cada habilidad requiere contexto técnico específico o confirmación de stack.
 


### PR DESCRIPTION
Closes #40

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- cambia Release Please para usar el secreto `RELEASE_PLEASE_TOKEN` en lugar de `GITHUB_TOKEN`
- quita Genkit del posicionamiento público en `README.md` y `docs/installation.md`
- mantiene intacto el routing interno para no romper compatibilidad futura

## Changes Table
| File | Change |
|------|--------|
| `.github/workflows/release-please.yml` | Usa `RELEASE_PLEASE_TOKEN` para destrabar checks de release PRs |
| `README.md` | Quita Genkit de la capa pública de habilidades especializadas |
| `docs/installation.md` | Quita Genkit de la documentación pública de instalación |

## Test Plan
- [x] Validado que el secreto `RELEASE_PLEASE_TOKEN` ya existe en el repo
- [x] Revisado el diff para confirmar que Genkit solo sale de la capa pública y no del routing interno
- [x] No se modificaron scripts; `shellcheck` solo valida el workflow existente

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (N/A, no scripts modified)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers