### PR TITLE
docs(readme): clarify non-routable awesome-copilot candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Idea → brainstorming → descubrimiento de producto → factibilidad técnica 
 
 ## Habilidades Disponibles
 
+> **Estado actual**: Ninguna habilidad derivada de `awesome-copilot` está disponible en este release. El cambio `adapt-awesome-copilot-skills-to-our-flow` es de documentación (MVP docs-first y non-routable). Las candidatas (`agent-governance`, `agentic-eval`) están documentadas en el registry como no instalables y no enrutableables hasta una futura migración.
+> **Ownership**: Las candidatas respetan un deny-list explícito (ver `.atl/skill-registry.md` → `## External Adaptation Gate` → `### Ownership Deny-List`): `agent-governance` no compite con `repo-bootstrap`, `branch-pr` ni `issue-creation`; `agentic-eval` no compite con `sdd-verify`.
+> **Nota de alcance**: Este cambio modifica únicamente `.atl/skill-registry.md`, `README.md` y `docs/installation.md`. Otros diffs en la rama (ej. `.github/workflows/release-please.yml`) son ajenos a este cambio y se tratan por separado.
+
 ### 1. Inicio de proyecto (brainstorming → descubrimiento → factibilidad)
 
 | Habilidad | Propósito |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -148,6 +148,22 @@ Bootstrap/Scripts (físico)  →  Hace que opencode DETECTE las habilidades
 - **Bootstrap**: `scripts/install-opencode-skills.sh` instala habilidades del repo a `~/.config/opencode/skills/`
 - **Brecha actual**: Las habilidades externas requieren bootstrap + reinicio de opencode para quedar disponibles
 
+### Candidatas Externas (Non-Routable)
+
+Las habilidades candidatas documentadas en el `.atl/skill-registry.md` bajo `## External Adaptation Gate` (como `agent-governance` o `agentic-eval`) **no son instalables ni enrutableables** en este release.
+
+- **Solo las carpetas físicas** que contienen un archivo `SKILL.md` y son procesadas por el `bootstrap` quedan disponibles para opencode.
+- Las entradas en el registry bajo `## External Adaptation Gate` son **lógicas únicamente** y no activan routing ni instalación.
+- Para que una candidata sea instalable, debe cumplir con los criterios de entrada futura (tener un `SKILL.md` nativo, scope único, etc.) y migrar a `## User Skills` en el registry.
+
+#### Ownership Deny-List (reiteración mínima)
+Consulte `.atl/skill-registry.md` → `## External Adaptation Gate` → `### Ownership Deny-List` para el detalle oficial. En resumen:
+- `agent-governance` **no compite** con `repo-bootstrap`, `branch-pr`, `issue-creation` (ownership fuera de alcance).
+- `agentic-eval` **no compite** con `sdd-verify` (ownership fuera de alcance).
+
+#### Nota de alcance (isolation disclaimer)
+El cambio `adapt-awesome-copilot-skills-to-our-flow` modifica **únicamente** `.atl/skill-registry.md`, `README.md` y `docs/installation.md`. Cualquier otro diff presente en la rama (por ejemplo, `.github/workflows/release-please.yml`) pertenece a cambios independientes y **no forma parte del scope** de esta adaptación.
+
 ---
 
 ## Referencias


### PR DESCRIPTION
Closes #42

## Summary
- documenta que las candidatas derivadas de awesome-copilot quedan deferred/non-routable en este release
- aclara la separación entre routing lógico y disponibilidad física para evitar falsas expectativas
- reitera ownership boundaries y el aislamiento de alcance documental frente a diffs ajenos en la rama

## Checklist
- [x] Este PR está ligado a un issue aprobado (`status:approved`)
- [x] No hice push directo a `main`
- [x] Este cambio vive en una rama de trabajo
- [x] Usé Conventional Commits
- [x] Validé impacto funcional manual o con tests
- [x] Actualicé docs si era necesario
- [x] Consideré impacto en release
- [x] Este repo usa `release-please` y este cambio está pensado para convivir con ese flujo

## Release Please
- [ ] `feat:` si debe generar minor release
- [ ] `fix:` si debe generar patch release
- [ ] `BREAKING CHANGE:` o `!` si debe generar major release
- [x] `docs:` / `chore:` / `refactor:` si no debe disparar release funcional

## Testing / Validación
- [x] Revisé manualmente el cambio
- [x] Corrí pruebas relevantes si existen

## Riesgos
- cambio puramente documental y reversible
- la referencia a `.atl/skill-registry.md` depende de contexto local/documental, sin activar runtime nuevo

## Evidencia
- diff limitado a `README.md` y `docs/installation.md`
- issue aprobado: #42
- SDD archivado para `adapt-awesome-copilot-skills-to-our-flow`