### PR TITLE
docs(skills): stabilize governance and routing

### DIFF
--- a/.atl/skill-registry.md
+++ b/.atl/skill-registry.md
@@ -1,0 +1,319 @@
+# Skill Registry
+
+**Delegator use only.** Any agent that launches sub-agents reads this registry to resolve compact rules, then injects them directly into sub-agent prompts. Sub-agents do NOT read this registry or individual SKILL.md files.
+
+> **External Skills Availability**: Este registry define **orquestación lógica** (cuándo activar cada skill según contexto y fase). No garantiza disponibilidad física en el entorno. Las skills marcadas como `external-bootstrappable` residen fuera del repo en `${AGENTS_DIR}` (por defecto `$HOME/.agents/skills`, configurable vía `EXTERNAL_SKILLS_DIR` en el bootstrap) y requieren instalación manual o ejecución del bootstrap (`bash scripts/bootstrap.sh`) para estar disponibles en `~/.config/opencode/skills`. Sin instalación física, opencode no las detectará y el enrutamiento será solo lógico. Skills marcadas como `logical-only` existen como reglas de routing/candidato sin instalación garantizada.
+
+## User Skills
+
+| Trigger | Skill | Path | State |
+|---------|-------|------|-------|
+| PASO 1 de un pipeline de definición de producto | brainstorm | ./brainstorm/SKILL.md | repo-local |
+| PASO 2 de un pipeline de definición de producto | product-discovery | ./product-discovery/SKILL.md | repo-local |
+| Skill de transición entre discovery y factibilidad | project-init | ./project-init/SKILL.md | repo-local |
+| PASO 4 de un pipeline de definición de producto | tech-feasibility | ./tech-feasibility/SKILL.md | repo-local |
+| Criterio personal para proyectos Flutter | flutter-personal-standards | ./dev-skills/flutter-personal-standards/SKILL.md | repo-local |
+| Skill ejecutiva para preparar un repositorio | repo-bootstrap | ./dev-skills/repo-bootstrap/SKILL.md | repo-local |
+| Revisión de arquitectura de proyecto | improve-codebase-architecture | ./dev-skills/improve-codebase-architecture/SKILL.md | repo-local |
+| Debugging sistemático de errores | diagnose | ./dev-skills/diagnose/SKILL.md | repo-local |
+| Perspectiva de sistema antes de editar | zoom-out | ./dev-skills/zoom-out/SKILL.md | repo-local |
+| Stack Supabase confirmado en tech-feasibility | supabase | ${AGENTS_DIR}/supabase/SKILL.md | external-bootstrappable |
+| SQL/RLS/Postgres en fase de diseño/implementación | supabase-postgres-best-practices | ${AGENTS_DIR}/supabase-postgres-best-practices/SKILL.md | external-bootstrappable |
+| Firebase confirmado en tech-feasibility / setup de proyecto | firebase-basics | ${AGENTS_DIR}/firebase-basics/SKILL.md | external-bootstrappable |
+| Auth/sign-in/providers/tokens en Firebase | firebase-auth-basics | ${AGENTS_DIR}/firebase-auth-basics/SKILL.md | external-bootstrappable |
+| Firestore Standard: queries, índices, SDK, reglas | firebase-firestore-standard | ${AGENTS_DIR}/firebase-firestore-standard/SKILL.md | external-bootstrappable |
+| Firestore Enterprise Native Mode explícito | firebase-firestore-enterprise-native-mode | ${AGENTS_DIR}/firebase-firestore-enterprise-native-mode/SKILL.md | external-bootstrappable |
+| Hosting clásico: estático/SPA sin SSR | firebase-hosting-basics | ${AGENTS_DIR}/firebase-hosting-basics/SKILL.md | external-bootstrappable |
+| Next.js/Angular/SSR/App Hosting explícito | firebase-app-hosting-basics | ${AGENTS_DIR}/firebase-app-hosting-basics/SKILL.md | external-bootstrappable |
+| Revisar/endurecer Security Rules de Firestore/Storage | firebase-security-rules-auditor | ${AGENTS_DIR}/firebase-security-rules-auditor/SKILL.md | external-bootstrappable |
+| Data Connect / SQL Connect / GraphQL / Postgres SDK | firebase-data-connect | ${AGENTS_DIR}/firebase-data-connect/SKILL.md | external-bootstrappable |
+| Firebase AI Logic / Gemini desde cliente | firebase-ai-logic-basics | ${AGENTS_DIR}/firebase-ai-logic-basics/SKILL.md | external-bootstrappable |
+| Genkit en JS/TS | developing-genkit-js | ${AGENTS_DIR}/developing-genkit-js/SKILL.md | external-bootstrappable |
+| Genkit en Dart/Flutter | developing-genkit-dart | ${AGENTS_DIR}/developing-genkit-dart/SKILL.md | external-bootstrappable |
+| Genkit en Go | developing-genkit-go | ${AGENTS_DIR}/developing-genkit-go/SKILL.md | external-bootstrappable |
+| Genkit en Python | developing-genkit-python | ${AGENTS_DIR}/developing-genkit-python/SKILL.md | external-bootstrappable |
+| Advisory/warning-first sobre ramas, PRs y commits | repo-guardrails | ./dev-skills/repo-guardrails/SKILL.md | repo-local |
+| Export-only de artifacts SDD a GitHub issues | sdd-to-issues | ./dev-skills/sdd-to-issues/SKILL.md | repo-local |
+| Enrutador opt-in de requests a SDD/skills/issues | request-triage | ./dev-skills/request-triage/SKILL.md | repo-local |
+| Clarificación opt-in usando artifacts existentes | clarify-with-artifacts | ./dev-skills/clarify-with-artifacts/SKILL.md | repo-local |
+| Crear nuevas AI skills | skill-creator | ${AGENTS_DIR}/skill-creator/SKILL.md | logical-only |
+
+## Compact Rules
+
+### brainstorm
+- Convierte idea vaga en Product Brief; no saltes al stack.
+- Orden: problema → usuario → propuesta de valor → MVP → diferenciadores → dudas.
+- Pide una explicación de 30 segundos y desafía "para todos".
+- El MVP debe ser lo mínimo que resuelve el problema principal.
+- Termina con output útil y listo para pasar a discovery.
+
+### product-discovery
+- Valida si el problema existe, quién lo sufre y qué alternativa usa hoy.
+- Usa ruta ligera para side projects; no fuerces discovery pesado.
+- Busca competencia directa, indirecta y sustitutos.
+- Resume usuario + JTBD + propuesta de valor con claridad.
+- Antes de construir, define la forma más barata de validar interés.
+
+### project-init
+- Skill de transición entre product-discovery y tech-feasibility.
+- Recibe Discovery Report → produce Project Framing Doc.
+- Enfoque: predictivo (requisitos claros) / adaptativo (evolucionan) / híbrido.
+- Define fases ligeras según el contexto real del proyecto; no impone un modelo universal.
+- Gobernanza mínima: decisiones, cambios y criterios de avance hacia factibilidad técnica.
+- **Bypass**: salto opcional a tech-feasibility cuando el proyecto es pequeño.
+
+### tech-feasibility
+- Evalúa factibilidad técnica, no gustos por frameworks.
+- Inventaría features del MVP y marca auth, persistencia, tiempo real, offline, etc.
+- Propón alternativas con tradeoffs; no digas "usa X" sin contexto.
+- Estima con rangos y señala incertidumbre; prototipa lo incierto.
+- La arquitectura debe ser proporcional al alcance.
+- **Input aceptados**: Project Framing Doc (principal) o Discovery Report (bypass).
+
+### flutter-personal-standards
+- Empieza simple y escala solo cuando el alcance lo pida.
+- Elige estado según alcance real: local → setState, compartido → Provider/ChangeNotifier, escalable → Riverpod/Bloc.
+- No impongas GetX si el proyecto no lo exige.
+- Separa UI, estado e IO; no mezcles todo en un widget.
+- Si el caso ya es específico, enruta a la skill oficial de Flutter correspondiente.
+
+### repo-bootstrap
+- No push directo a main; todo entra por PR.
+- `release-please` y Conventional Commits son obligatorios en proyectos nuevos.
+- Ningún merge sin checks funcionales reales del stack.
+- Auto-merge solo después de PR validation + checks verdes.
+- En repos privados Free personales, el hook local `pre-push` es parte de la protección.
+
+### improve-codebase-architecture
+- Revisión de arquitectura enfocada en deuda, acoplamiento y violaciones.
+- Integra con SDD: úsala antes de `sdd-propose` o `sdd-design`.
+- No la uses para debugging puntual; para eso usa `diagnose`.
+- Produce un resumen ejecutivo breve, no un tratado.
+- Si el proyecto es pequeño, di "acoplado / sin estructura" y recomienda pasos mínimos.
+- **Main skill** para revisión arquitectónica transversal; `improve-codebase-architecture` es la primaria de las tres.
+- **Precedencia**: skills de stack (Flutter/Firebase/Supabase/Genkit) ganan si el problema es específico de ese stack.
+- **Fallback**: si no hay código suficiente o el usuario está en `brainstorm`/`discovery`, no activar; usar fase upstream.
+- **SDD explícito gana**: si hay comando `/sdd-*`, usarlo en lugar de esta skill.
+
+### diagnose
+- Debugging canónico: repro → minimiza → instrumenta → fix → regresión.
+- Úsala para errores concretos, no para revisiones amplias de arquitectura.
+- No hagas refactors mientras debuggeas; enfócate en el fix mínimo.
+- Integra con SDD: si el bug revela necesidad de cambio estructural, luego enruta a `sdd-propose`.
+- Output: reporte breve con reproducción, causa raíz, fix y regresión.
+- **Companion skill** para debugging puntual; no es reemplazo de `improve-codebase-architecture`.
+- **Precedencia**: si el bug es puramente de framework (Flutter/Firebase), usar skill oficial de stack en su lugar.
+- **Fallback**: si no hay error reproducible o el usuario está en fase diseño/propuesta, no activar.
+- **SDD explícito gana**: si hay comando `/sdd-*`, usarlo en lugar de esta skill.
+
+### zoom-out
+- Perspectiva de sistema antes de editar código desconocido.
+- Mapea dependencias, flujo de datos y riesgos de edición.
+- Úsala antes de `sdd-apply` o `sdd-design` en módulos que no dominas.
+- No hagas cambios aquí; solo mapa y diagnóstico de riesgos.
+- Output súper breve: dependencias, flujo, riesgos y recomendación.
+- **Companion skill** para contexto previo a edición; no es análisis arquitectónico profundo.
+- **Precedencia**: omitir si el módulo ya es conocido o el cambio es mecánico.
+- **Fallback**: si no hay código suficiente o el usuario apenas inicia, no activar.
+- **SDD explícito gana**: si hay comando `/sdd-*`, usarlo en lugar de esta skill.
+
+### supabase
+- Activar tras decisión de stack en `tech-feasibility`; no antes.
+- Incluye integración general: auth, realtime, storage, database.
+- Si la skill no está instalada en `~/.config/opencode/skills`, el routing es solo lógico y requiere bootstrap manual desde `${AGENTS_DIR}/supabase/`.
+
+### supabase-postgres-best-practices
+- Activar solo en fases de diseño/apply con contexto SQL, RLS, migrations o esquema Postgres.
+- No activar solo por haber elegido Supabase como stack.
+- Requiere trabajo técnico específico: performance, índices, políticas RLS, esquema relacional.
+
+### skill-creator
+- Solo referencia documental para crear nuevas AI skills.
+- NO participa en routing normal ni en el pipeline de desarrollo estándar.
+- No está incluida en el bootstrap por defecto; requiere instalación manual desde `.claude/skills/` si se necesita.
+
+### firebase-basics
+- Activar tras decisión de stack en `tech-feasibility` o cuando la conversación pida inicialización/CLI/proyecto Firebase.
+- Incluye configuración general: autenticación, proyectos, comandos CLI, reglas base.
+- Si la skill no está instalada en `~/.config/opencode/skills`, el routing es solo lógico y requiere bootstrap manual desde `${AGENTS_DIR}/firebase-basics/`.
+
+### firebase-auth-basics
+- Activar con trabajo específico de Auth: sign-in, providers, tokens, reglas con `request.auth`.
+- No activar solo por haber elegido Firebase; debe haber contexto de autenticación.
+- Requiere `firebase-basics` confirmado o implícito.
+
+### firebase-firestore-standard
+- Activar con trabajo específico de Firestore Standard: modelo documento, queries, índices, SDK, reglas de seguridad.
+- NO activar por mencionar Firebase genéricamente.
+- Requiere contexto técnico de base de datos documental.
+
+### firebase-firestore-enterprise-native-mode
+- Activar SOLO si el usuario confirma explícitamente Enterprise Native Mode.
+- Es mutuamente excluyente con `firebase-firestore-standard`; no mezclar guías.
+- No activar por default ni por solo mencionar Firestore.
+
+### firebase-hosting-basics
+- Activar para hosting clásico: sitio estático, Single Page Apps (SPA) sin SSR.
+- NO activar para Next.js/Angular SSR; usar `firebase-app-hosting-basics` en su lugar.
+- Requiere distinción clara entre hosting estático y App Hosting.
+
+### firebase-app-hosting-basics
+- Activar para Next.js/Angular/full-stack con SSR, ISR o App Hosting explícito.
+- NO activar para hosting clásico/estático; usar `firebase-hosting-basics` en su lugar.
+- Requiere confirmación de framework con SSR o App Hosting.
+
+### firebase-security-rules-auditor
+- Activar cuando se creen, revisen o endurezcan Security Rules de Firestore o Storage.
+- Ideal como auditoría/review, no como skill umbrella para todo Firebase.
+- No activar prematuramente; requiere reglas concretas que auditar.
+
+### firebase-data-connect
+- Activar solo con trabajo de SQL Connect, Data Connect, PostgreSQL, GraphQL o SDKs generados.
+- No activar por solo elegir Firebase o mencionar base de datos.
+- Requiere contexto de SQL/Postgres/GraphQL.
+
+### firebase-ai-logic-basics
+- Activar cuando el trabajo sea Firebase AI Logic / Gemini desde cliente (web/app).
+- Complementa a Genkit, no lo sustituye; puede coexistir.
+- Requiere contexto de IA generativa en Firebase.
+
+### developing-genkit-js
+- Activar cuando haya trabajo Genkit en JS/TS (Node.js/TypeScript).
+- Para Flutter/Dart usar `developing-genkit-dart`; para Go usar `developing-genkit-go`; para Python usar `developing-genkit-python`.
+- No activar para otros lenguajes; requiere stack JS/TS confirmado.
+- State: external-bootstrappable — requiere bootstrap desde `${AGENTS_DIR}` o instalación manual.
+
+### developing-genkit-dart
+- Activar cuando haya trabajo Genkit en Dart/Flutter.
+- Para JS/TS usar `developing-genkit-js`; para Go usar `developing-genkit-go`; para Python usar `developing-genkit-python`.
+- No activar para otros lenguajes; requiere stack Dart/Flutter confirmado.
+- State: external-bootstrappable — requiere bootstrap desde `${AGENTS_DIR}` o instalación manual.
+
+### developing-genkit-go
+- Activar cuando haya trabajo Genkit en Go.
+- Para JS/TS usar `developing-genkit-js`; para Dart/Flutter usar `developing-genkit-dart`; para Python usar `developing-genkit-python`.
+- No activar para otros lenguajes; requiere stack Go confirmado.
+- State: external-bootstrappable — requiere bootstrap desde `${AGENTS_DIR}` o instalación manual.
+
+### developing-genkit-python
+- Activar cuando haya trabajo Genkit en Python.
+- Para JS/TS usar `developing-genkit-js`; para Dart/Flutter usar `developing-genkit-dart`; para Go usar `developing-genkit-go`.
+- No activar para otros lenguajes; requiere stack Python confirmado.
+- State: external-bootstrappable — requiere bootstrap desde `${AGENTS_DIR}` o instalación manual.
+
+### repo-guardrails
+- Capa advisory/warning-first; NO bloquea ni reemplaza `repo-bootstrap`.
+- Input: estado rama/PR/repo + reglas `repo-bootstrap` / `docs/governance.md`.
+- Output: warnings/checklist inline; referir a `repo-bootstrap` para normas.
+- Si hay comando `/sdd-*`, gana SDD; `repo-guardrails` cede.
+
+### sdd-to-issues
+- Export-only: convierte artifacts SDD (spec/design/tasks) en issues GitHub vía `issue-creation`.
+- NO descompone trabajo; eso es territorio exclusivo de `sdd-tasks`.
+- Fallback: sin artifacts SDD → no genera nada, sugiere usar SDD primero.
+- `issue-creation` / `branch-pr` ganan para crear/aprobar issues y PRs.
+
+### request-triage
+- Enrutador opt-in y ultra-delgado; solo decide destino (SDD/skill/issue).
+- NO aclara contenido (usa `clarify-with-artifacts` para eso).
+- NO parte trabajo; solo da recomendación inline.
+- Comando `/sdd-*` explícito gana siempre; `request-triage` cede.
+
+### clarify-with-artifacts
+- Helper opt-in que estructura contexto usando docs/artifacts existentes.
+- NO sustituye `sdd-propose` ni `sdd-spec`; output mínimo inline.
+- NO escribe artifacts canónicos; SDD manda en eso.
+- Fallback: sin artifacts previos → sugerir `brainstorm` o `sdd-init`.
+
+## Anti-Solape
+
+**Regla general**: Si el trigger coincide con una skill de stack (Flutter/Firebase/Supabase/Genkit) Y también coincide con una de las 3 skills de arquitectura (`improve-codebase-architecture`, `diagnose`, `zoom-out`), **gana la skill de stack**.
+
+### Precedencia General
+
+| Escenario | Skill que gana | Razón |
+|-----------|----------------|-------|
+| Bug en Flutter + `diagnose` | Skill oficial Flutter (ej. `flutter-architecting-apps`) | El problema es específico de ese stack |
+| Revisión arquitectónica + proyecto Flutter | `improve-codebase-architecture` (transversal) O `flutter-architecting-apps` | Según si el problema es de arquitectura general o específico de Flutter |
+| Contexto previo a editar + módulo Supabase | `supabase` o `supabase-postgres-best-practices` | El problema es específico de ese stack |
+| Comando `/sdd-*` explícito | Fase SDD correspondiente | SDD manda; estas 3 skills son solo companions previos |
+
+### Precedencia: Skills Derivadas vs Flujo Existente
+
+| Escenario | Skill que gana | Razón |
+|-----------|----------------|-------|
+| Comando `/sdd-*` explícito | Fase SDD (`sdd-propose`, `sdd-spec`, etc.) | SDD es fuente de verdad para planificación |
+| Partición de trabajo | `sdd-tasks` | `sdd-to-issues` solo exporta, no descompone |
+| Crear/aprobar issues y PRs | `issue-creation` / `branch-pr` | `sdd-to-issues` es canal de salida, no dueño |
+| Normas del repo | `repo-bootstrap` | `repo-guardrails` es capa advisory lateral |
+| Aclaración de contenido profundo | `sdd-propose` / `sdd-spec` | `clarify-with-artifacts` es helper opt-in |
+| Request ambiguo | `request-triage` decide; si hay `/sdd-*` gana SDD | `request-triage` es solo router |
+
+**Ownership claro**:
+- SDD planea y escribe artifacts canónicos.
+- Engram persiste memoria y artifacts SDD.
+- `issue-creation` / `branch-pr` gobiernan issues/PRs.
+- `repo-bootstrap` fija guardrails normativos del repo.
+- Las 4 skills derivadas son helpers/advisory/export-only y NO reemplazan a los anteriores.
+
+**Principio**: Las 3 skills arquitectónicas son **herramientas tácticas transversales**. Si el problema tiene un stack definido, la skill de stack tiene prioridad porque conoce los patrones específicos.
+
+**Fallback de no disponibilidad**: Las skills `improve-codebase-architecture`, `diagnose` y `zoom-out` residen en `dev-skills/` y están disponibles localmente. Para skills externas (ej. Firebase, Supabase, Genkit en `${AGENTS_DIR}`), si no están instaladas en `~/.config/opencode/skills`, el routing es solo lógico y requiere bootstrap manual.
+
+## Project Conventions
+
+No se detectaron archivos de convención de proyecto en la raíz (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `GEMINI.md`, `copilot-instructions.md`).
+
+## Pipeline
+
+```
+brainstorm → product-discovery → project-init → tech-feasibility
+```
+
+**Bypass (ruta ligera)**:
+```
+brainstorm → product-discovery → tech-feasibility
+```
+
+**Condiciones para bypass de project-init**:
+- Proyecto personal con alcance muy pequeño (1-2 features)
+- El usuario es el único interesado y decisor
+- No hay restricciones regulatorias ni organizacionales
+- tech-feasibility puede funcionar con Discovery Report directo
+
+**Outputs por etapa**:
+- brainstorm → Product Brief v4.0
+- product-discovery → Discovery Report v3.0
+- project-init → Project Framing Doc v1.0 (Project Charter como alias temporal)
+- tech-feasibility → Tech Spec v3.0
+
+## External Adaptation Gate
+
+This section documents external skill candidates (e.g., from awesome-copilot) that are being considered for future adoption. These candidates are **non-routable** and **not available for installation** in the current release.
+
+### Candidate Table
+
+| Candidate | Source | Status | Blocked By | Future Entry Criteria |
+|-----------|--------|--------|------------|----------------------|
+| `agent-governance` | awesome-copilot (external) | deferred | `repo-bootstrap`, `branch-pr`, `issue-creation` | Unique scope sentence, explicit "When NOT to Use", precedence row, availability disclaimer, real native `SKILL.md` |
+| `agentic-eval` | awesome-copilot (external) | deferred | `sdd-verify` | Unique scope sentence, explicit "When NOT to Use", precedence row, availability disclaimer, real native `SKILL.md` |
+
+### Ownership Deny-List
+
+The following domains are explicitly out of scope for this change. External-derived ideas cannot own these flows:
+
+- **`agent-governance`**: blocked while overlap exists with `repo-bootstrap`, `branch-pr`, `issue-creation`.
+- **`agentic-eval`**: blocked while overlap exists with `sdd-verify`.
+
+### Routing Rule
+
+**Only entries under `## User Skills` are routable.** Entries in this section are logical-only candidates and will NOT trigger skill loading or routing until they are formally migrated to `## User Skills` with a physical `SKILL.md` file.
+
+### Scope Isolation (Change: adapt-awesome-copilot-skills-to-our-flow)
+
+This change modifies **only** the following files:
+- `.atl/skill-registry.md` (this file)
+- `README.md`
+- `docs/installation.md`
+
+Any other diffs present in the branch (e.g., `.github/workflows/release-please.yml`) belong to separate changes and are **out of scope** for this adaptation. The ownership deny-list (`agent-governance` blocked by `repo-bootstrap`/`branch-pr`/`issue-creation`; `agentic-eval` blocked by `sdd-verify`) is reiterated in all three files for cross-document consistency.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@
 
 [![GitHub repo](https://img.shields.io/badge/GitHub-KkapsCa%2Fkkapsca--skills-blue?logo=github)](https://github.com/KapsCa/kkapsca-skills)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Follow Gentle AI](https://img.shields.io/badge/Follow-Gentle%20AI-purple?logo=github)](https://github.com/Gentleman-Programming/gentle-ai)
 
 Este repositorio reúne habilidades (**skills**) pensadas desde la experiencia personal de **KkapsCa**, optimizadas para flujos de trabajo asistidos por Inteligencia Artificial (como Cursor, Windsurf o **opencode**) y redactadas para que **cualquier persona pueda reutilizarlas** en sus propios proyectos.
-
-Al mismo tiempo, estas habilidades están **optimizadas para trabajar especialmente bien dentro del entorno tecnológico de [Gentle AI](https://github.com/Gentleman-Programming/gentle-ai)** y flujos coordinados por el **orquestador sdd-orchestrator** (una herramienta que coordina fases de desarrollo estructurado).
 
 ---
 
@@ -24,7 +21,7 @@ bash scripts/bootstrap.sh
 
 > **Nota**: El proceso de inicialización (**bootstrap**) se corre desde **este repositorio de habilidades**, no desde la carpeta de tu proyecto futuro. Reinicia opencode después de ejecutarlo.
 
-Para detalles operativos de instalación (opciones `--copy`, enlaces simbólicos, habilidades externas), consulta la [guía de instalación](docs/installation.md).
+Para detalles operativos de instalación (opciones `--copy`, enlaces simbólicos), consulta la [guía de instalación](docs/installation.md).
 
 ---
 
@@ -62,41 +59,6 @@ Idea → brainstorming → descubrimiento de producto → factibilidad técnica 
 
 ---
 
-## Habilidades Disponibles
-
-> Algunas habilidades de este repositorio están inspiradas en colecciones públicas como `awesome-copilot`, pero se incorporan aquí solo cuando encajan con el flujo, las reglas y el criterio de este proyecto.
->
-> **Nota:** Las habilidades derivadas de `awesome-copilot` aún **no están disponibles como parte del catálogo activo**. Por ahora solo se mantienen como **candidatas documentadas** para evaluación futura, sin instalación ni routing habilitado.
-> Si necesitas el detalle técnico, consulta `docs/installation.md` y `.atl/skill-registry.md`.
-
-### 1. Inicio de proyecto (brainstorming → descubrimiento → factibilidad)
-
-| Habilidad | Propósito |
-|-----------|-----------|
-| **brainstorm** | Convierte una idea vaga en un Product Brief |
-| **product-discovery** | Valida mercado, usuario, competencia y negocio |
-| **project-init** | Cierra la brecha entre descubrimiento y factibilidad |
-| **tech-feasibility** | Evalúa tecnología, riesgos, arquitectura y esfuerzo |
-
-### 2. Desarrollo y estándares
-
-| Habilidad | Propósito |
-|-----------|-----------|
-| **dev-skills/flutter-personal-standards** | Criterio personal para Flutter |
-| **dev-skills/repo-bootstrap** | Prepara el repositorio: flujo de PR, release-please, estándares |
-| **dev-skills/repo-guardrails** | Advisory/warning-first sobre ramas, PRs y commits (capa lateral) |
-| **dev-skills/sdd-to-issues** | Export-only: convierte artifacts SDD en issues GitHub |
-| **dev-skills/request-triage** | Enrutador opt-in que decide a dónde va un request |
-| **dev-skills/clarify-with-artifacts** | Estructura contexto usando artifacts existentes (opt-in) |
-
-### 3. Habilidades especializadas (requieren tecnología confirmada)
-
-Las habilidades de **Supabase** y **Firebase** se activan tras decidir la tecnología en `tech-feasibility`. Deben instalarse vía bootstrap para que opencode las detecte.
-
-Consulta la [guía de instalación](docs/installation.md) para disponibilidad real y `docs/engram.md` para entender cómo se separan inicialización, memoria persistente y orquestación.
-
----
-
 ## Filosofía
 
 - **Problema primero, tecnología después**
@@ -107,30 +69,18 @@ Consulta la [guía de instalación](docs/installation.md) para disponibilidad re
 
 ---
 
-## Documentación Detallada
+## Documentación
 
-Para detalles operativos, consulta la documentación en `docs/`:
+Para detalles operativos, consulta:
 
-| Tema | Documento |
-|------|-----------|
-| Contexto Gentle AI y relación con este repo | [docs/gentle-ai.md](docs/gentle-ai.md) |
-| Instalación detallada, bootstrap y skill-registry | [docs/installation.md](docs/installation.md) |
-| Memoria persistente (Engram) vs Bootstrap vs Skill-Registry | [docs/engram.md](docs/engram.md) |
-| Desarrollo estructurado (SDD) y sdd-orchestrator | [docs/sdd.md](docs/sdd.md) |
-| Flujo de contribución y branch protection | [docs/governance.md](docs/governance.md) |
-| Versionado semántico y release-please | [docs/release-please.md](docs/release-please.md) |
-| Configuración WSL para Windows | [docs/wsl-setup.md](docs/wsl-setup.md) |
-| Índice de documentación | [docs/README.md](docs/README.md) |
+- [Guía de instalación](docs/installation.md) — instalación detallada, bootstrap y opciones
+- [Índice de documentación](docs/README.md) — dónde encontrar contexto adicional (Gentle AI, SDD, Engram, contribución)
 
 ---
 
 ## Mejor Experiencia de Uso
 
-Estas habilidades dan mejores resultados cuando:
-
-- El agente opera con contexto consistente
-- Existe un **orquestador sdd-orchestrator** coordinando fases o subagentes
-- Y el entorno ya sigue las convenciones del entorno tecnológico de Gentle AI
+Estas habilidades dan mejores resultados cuando el agente opera con contexto consistente y el entorno ya sigue las convenciones de Gentle AI.
 
 Si quieres la mejor experiencia: [Gentle AI Repository](https://github.com/Gentleman-Programming/gentle-ai)
 
@@ -141,12 +91,9 @@ Si quieres la mejor experiencia: [Gentle AI Repository](https://github.com/Gentl
 Este proyecto utiliza herramientas y referentes que han contribuido a su desarrollo:
 
 - **[Gentleman-Programming/gentle-ai](https://github.com/Gentleman-Programming/gentle-ai)**: Por el entorno de trabajo, la filosofía de desarrollo y las herramientas que permitieron revisar, corregir y refinar este repositorio.
-- **[mattpocock/skills](https://github.com/mattpocock/skills)**: Por servir como referencia e inspiración para varias habilidades adaptadas a este ecosistema, especialmente en utilidades tácticas de arquitectura, diagnóstico y flujo de trabajo.
-- **Supabase**: Por sus habilidades oficiales que extienden las capacidades de este repositorio.
-- **Firebase**: Por sus habilidades oficiales que cubren casos de uso específicos en la plataforma.
+- **[mattpocock/skills](https://github.com/mattpocock/skills)**: Por servir como referencia e inspiración para varias habilidades adaptadas a este ecosistema.
+- **Supabase** y **Firebase**: Por sus habilidades oficiales que extienden las capacidades de este repositorio.
 - **Equipo de opencode**: Por la plataforma que hace posible la ejecución de estas habilidades.
-
-Este repositorio es un esfuerzo personal y no cuenta con patrocinio oficial de ninguna de las herramientas mencionadas. Las menciones se realizan únicamente para referencia técnica y reconocimiento de uso.
 
 ---
 

--- a/dev-skills/repo-bootstrap/SKILL.md
+++ b/dev-skills/repo-bootstrap/SKILL.md
@@ -28,6 +28,22 @@ metadata:
 
 ---
 
+## Governance Source of Truth
+
+> **⚠️ Normativo**: Este archivo es la **fuente normativa** de todas las reglas de gobernanza de repositorios en este ecosistema.
+> `docs/governance.md` es una **vista derivada operativa** que resume estas reglas sin contradecirlas. Si existe conflicto entre ambos documentos, este archivo prevalece.
+
+### Governance Modes
+
+| Modo | PR obligatorio | Approvals requeridos | Auto-merge | Branch protection |
+|------|---------------|---------------------|------------|-------------------|
+| **Solo-dev** | ✅ Siempre | 0 (GitHub no permite auto-aprobarse) | ✅ Solo tras checks verdes | Hook `pre-push` + branch protection si público; solo hook si privado Free |
+| **Team** | ✅ Siempre | ≥ 1 (configurable por equipo) | ✅ Solo tras checks + approvals | Classic branch protection completa obligatoria |
+
+Para implementación detallada, ver [Principios No Negociables](#principios-no-negociables-quick-reference) y [Decision Tree](#decision-tree).
+
+---
+
 ## When to Use
 
 Usa esta skill cuando:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,23 @@
-# Documentación de Soporte — KkapsCa Skills
+# Documentación — KkapsCa Skills
 
-> **📚 Docs de Soporte** — Esta sección contiene documentación operativa para usuarios y gestión del repositorio.
+> **📚 Navegación por intención** — Elige tu ruta según lo que necesites hacer.
 
-Este directorio contiene documentación operativa y de contexto para el uso de este repositorio de habilidades (**skills**). Si llegaste desde el [README principal](../README.md), aquí encontrarás el detalle de cada tema.
+## 🚀 Empezar
 
-Las habilidades se gestionan mediante el sistema **Skills.sh**, que coordina la instalación, registro y orquestación de las mismas en tu entorno local.
+- [README principal](../README.md) — Qué es el repositorio, instalación rápida, flujo recomendado
 
-## Orden de lectura recomendado
+## 📦 Instalar
 
-1. **[README.md](../README.md)** — La página principal: qué es el repositorio, instalación rápida, flujo recomendado e inventario de habilidades (skills).
-2. **[gentle-ai.md](gentle-ai.md)** — Contexto del stack Gentle AI y relación con este repositorio.
-3. **[installation.md](installation.md)** — Guía detallada de instalación, inicialización (bootstrap), enlaces simbólicos y habilidades externas.
-4. **[sdd.md](sdd.md)** — Desarrollo Guiado por Especificaciones (SDD) y el orquestador sdd-orchestrator.
-5. **[engram.md](engram.md)** — Diferencia entre memoria persistente (Engram), inicialización local y skill-registry.
-6. **[wsl-setup.md](wsl-setup.md)** — Recomendaciones para Windows/WSL y enlaces oficiales (solo si usas Windows).
-7. **[governance.md](governance.md)** — Flujo de contribución, protección de ramas, validación de PR y Conventional Commits.
-8. **[release-please.md](release-please.md)** — Versionado semántico automático, tipos de commit y Release PR.
+- [Guía de instalación](installation.md) — Bootstrap, opciones `--copy`, enlaces simbólicos, desinstalación
+
+## 📖 Contexto Adicional (Opcional)
+
+- [Contexto Gentle AI](gentle-ai.md) — Stack Gentle AI y relación con este repo
+- [Memoria Persistente (Engram)](engram.md) — Diferencia entre Engram, bootstrap y skill-registry
+- [Desarrollo Estructurado (SDD)](sdd.md) — SDD y sdd-orchestrator
+
+## ⚙️ Operación del Repositorio
+
+- [Flujo de contribución](governance.md) — Protección de ramas, PR, Conventional Commits
+- [Versionado semántico](release-please.md) — Release-please y tipos de commit
+- [Configuración WSL](wsl-setup.md) — Recomendaciones para Windows/WSL

--- a/docs/engram.md
+++ b/docs/engram.md
@@ -114,9 +114,9 @@ Si la skill no está físicamente instalada, el enrutamiento (routing) fallará 
 
 1. **Engram** → memoria y contexto que sobrevive entre sesiones
 2. **Bootstrap (`bash scripts/bootstrap.sh`)** → hace que opencode vea las skills del repo localmente
-3. **`.atl/skill-registry.md`** → solo lo usa la orquestación SDD, no afecta la detección local de skills
-4. **Skills externas** (como `supabase` y Firebase) → el bootstrap las procesa por defecto desde la carpeta configurada en `EXTERNAL_SKILLS_DIR`; usa esa variable solo si quieres otra fuente
-5. **Firebase skills** → no activar solo por mencionar Firebase; requieren contexto técnico específico o confirmación de stack
+3. **`.atl/skill-registry.md`** → solo lo usa la orquestación SDD; incluye columna `State` (repo-local, external-bootstrappable, logical-only) para distinguir disponibilidad real de routing lógico. No afecta la detección local de skills.
+4. **Skills externas** (Supabase, Firebase, Genkit) → el bootstrap las procesa por defecto desde `${AGENTS_DIR}` (equivale a `$HOME/.agents/skills`). Usa `EXTERNAL_SKILLS_DIR` solo si quieres otra fuente.
+5. **Firebase skills** → no activar solo por mencionar Firebase; requieren contexto técnico específico o confirmación de stack.
 
 Si tu repo ya usa Engram, úsalo para recordar contexto y decisiones; **igual debes correr el bootstrap** para que opencode detecte las skills del repo. Para skills externas, documenta la dependencia y proporciona una guía de instalación. No actives skills de Firebase prematuramente.
 
@@ -128,18 +128,20 @@ El script actual **sí puede exponer skills externas** y por defecto usa `EXTERN
 2. Procesa directorios externos desde `"${EXTERNAL_SKILLS_DIR}"/*` cuando la variable apunta a una carpeta válida (o a la ruta por defecto)
 3. Puede enlazar skills de la carpeta externa hacia `~/.config/opencode/skills/`
 
-### Implicaciones para Supabase
+### Skills Externas
 
-- Las skills `supabase` y `supabase-postgres-best-practices` pueden enlazarse con `scripts/install-opencode-skills.sh`; por defecto ya toma `${HOME}/.agents/skills` como fuente externa
-- El `.atl/skill-registry.md` define orquestación lógica (cuándo activar), pero sin instalación física, opencode no las detectará
-- **No se promete autoactivación real**: cualquier documentación debe indicar que requiere paso previo de instalación o bootstrap con skills externas
+El registry ahora usa una convención portable (`${AGENTS_DIR}`) en lugar de rutas absolutas. El estado de cada skill se indica en la columna `State`:
 
-### Implicaciones para Firebase
+- **external-bootstrappable**: La skill existe en `${AGENTS_DIR}` (por defecto `$HOME/.agents/skills`). El bootstrap la procesa si el directorio externo está configurado.
+- **repo-local**: Vive en este repositorio.
+- **logical-only**: Candidato o referencia sin instalación garantizada.
 
-- Las 10 skills de Firebase pueden enlazarse con `scripts/install-opencode-skills.sh`; por defecto ya toma `${HOME}/.agents/skills` como fuente externa
-- El `.atl/skill-registry.md` define orquestación lógica (cuándo activar cada una), pero sin instalación física, opencode no las detectará
-- **No activar skills Firebase solo por mencionar Firebase**: requieren contexto técnico específico o confirmación de stack
-- **No se promete autoactivación real**: cualquier documentación debe indicar que requiere paso previo de instalación o bootstrap con skills externas
+Para cualquier skill externa (Supabase, Firebase, Genkit), aplica el mismo principio:
+
+- El `.atl/skill-registry.md` define orquestación lógica (cuándo activar), pero sin instalación física opencode no las detectará.
+- **No se promete autoactivación real**: cualquier documentación debe indicar que requiere paso previo de instalación o bootstrap con skills externas.
+- **No activar skills Firebase solo por mencionar Firebase**: requieren contexto técnico específico o confirmación de stack.
+- **Genkit**: cada lenguaje tiene su propia skill (`developing-genkit-{js,dart,go,python}`) con trigger específico. Consultar la matriz en el registry para el routing correcto.
 
 ### Fallback Guidance
 

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,19 +1,27 @@
 # Governance — Flujo de Contribución y Branch Protection
 
-Este documento describe las reglas operativas de este repositorio: protección de ramas, flujo de Pull Requests, validaciones y convenciones de commits.
+> **Vista derivada operativa.** Los recursos normativos de gobernanza viven en [`dev-skills/repo-bootstrap/SKILL.md`](../dev-skills/repo-bootstrap/SKILL.md).
+> Este documento resume las reglas para consulta rápida sin contradecir la fuente. Si existe conflicto, prevalece `repo-bootstrap/SKILL.md`.
 
 ## Branch Protection en `main`
 
-Este repositorio **requiere** que la rama `main` tenga protección habilitada en GitHub. La configuración se aplica **manualmente en la interfaz de GitHub** (no se puede configurar mediante archivos en el repositorio).
+Este repositorio **requiere** que la rama `main` tenga protección habilitada en GitHub. La configuración de protección varía según el modo de gobernanza:
 
-### Configuración requerida
+| Modo | Approvals requeridos | Aplica a |
+|------|---------------------|----------|
+| **Solo-dev** | 0 (GitHub no permite auto-aprobarse) | Proyectos personales / un solo contribuidor |
+| **Team** | ≥ 1 | Equipos con múltiples contribuidores |
+
+La configuración se aplica **manualmente en la interfaz de GitHub** (Settings → Branches → Branch protection rules), complementada por el hook local `pre-push` que instala `repo-bootstrap`.
+
+### Configuración requerida (modo Team)
 
 En GitHub: **Settings → Branches → Branch protection rules**
 
 | Configuración | Valor |
 |-------------|-------|
 | Branch name pattern | `main` |
-| ✅ Require pull request reviews before merging | 1 aprobación requerida |
+| ✅ Require pull request reviews before merging | ≥ 1 aprobación requerida |
 | ✅ Require status checks to pass before merging | selecciona los checks de PR validation |
 | ✅ Require conversation resolution | habilitado |
 | ✅ Require branches to be up to date before merging | habilitado |
@@ -21,10 +29,25 @@ En GitHub: **Settings → Branches → Branch protection rules**
 | ❌ Allow deletions | **DESACTIVADO** |
 | ✅ Include administrators | habilitado |
 
+### Configuración requerida (modo Solo-dev)
+
+| Configuración | Valor |
+|-------------|-------|
+| Branch name pattern | `main` |
+| ✅ Require pull request reviews before merging | **0 aprobaciones requeridas** |
+| ✅ Require status checks to pass before merging | selecciona los checks de PR validation |
+| ✅ Require conversation resolution | habilitado |
+| ✅ Require branches to be up to date before merging | habilitado |
+| ❌ Allow force pushes | **DESACTIVADO** |
+| ❌ Allow deletions | **DESACTIVADO** |
+| ✅ Include administrators | habilitado |
+
+> **Nota para repos privados Free**: GitHub puede mostrar "Not enforced" en la UI de branch protection. En ese caso, el hook local `pre-push` es la red de seguridad real. Ver `repo-bootstrap` para la instalación del hook.
+
 ### Por qué esto importa
 
 - **Sin protección en main**: cualquiera puede hacer push directo → se pierde trazabilidad
-- **Sin require approvals**: se pueden mergear cambios sin review
+- **Sin require approvals** (modo team): se pueden mergear cambios sin review
 - **Sin status checks**: cambios que no pasan validaciones pueden llegar a main
 
 ## Flujo de Contribución
@@ -33,16 +56,43 @@ Regla de oro: **No seas ese wey que hace push directo a main** 😤
 
 ### Pasos
 
+#### Modo Solo-dev
+
 1. Crear branch descriptivo: `feature/nombre-descriptivo` o `fix/nombre-descriptivo`
 2. Trabajar con commits en formato **Conventional Commits**
 3. Abrir Pull Request con:
    - Labels `type:*` y `status:approved`
    - Referencia a issue (ej. `Closes #N`)
    - Todos los status checks pasando
-4. Esperar aprobación y validación
-5. **Auto-merge** solo después de validación exitosa + checks verdes
+4. Esperar a que pasen los checks de validación (no requiere approvals)
+5. **Auto-merge** después de validación exitosa + checks verdes
+
+#### Modo Team
+
+1. Crear branch descriptivo: `feature/nombre-descriptivo` o `fix/nombre-descriptivo`
+2. Trabajar con commits en formato **Conventional Commits**
+3. Abrir Pull Request con:
+   - Labels `type:*` y `status:approved`
+   - Referencia a issue (ej. `Closes #N`)
+   - Todos los status checks pasando
+4. Esperar ≥1 approval + validación exitosa
+5. **Auto-merge** solo después de approvals + checks verdes
 
 ### Workflow esperado
+
+#### Solo-dev
+
+```text
+1. Crear branch feature/fix-descriptive-name
+2. Trabajar con commits Conventional Commits
+3. Abrir PR con labels type:*, status:approved
+4. Esperar a que pase PR validation (incluye conventional commits check)
+5. Una vez checks verdes → merge (approvals NO requeridos)
+6. release-please detecta y crea Release PR
+7. Al mergear Release PR → tag + release
+```
+
+#### Team
 
 ```text
 1. Crear branch feature/fix-descriptive-name

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Instalación Detallada — KkapsCa Skills
 
-Este documento cubre el detalle operativo de instalación de las habilidades (**skills**) en tu entorno local usando el sistema **Skills.sh**.
+Este documento cubre el detalle operativo de instalación de las habilidades (**skills**) en tu entorno local.
 
 ## Inicio Rápido
 
@@ -22,9 +22,7 @@ bash scripts/bootstrap.sh
 
 ## ¿Qué hace el bootstrap?
 
-- Registra cada carpeta que contiene `SKILL.md`
-- Instala tanto las habilidades raíz como las de `dev-skills/`
-- Usa `~/.config/opencode/skills` por defecto (configurable vía `OPENCODE_SKILLS_DIR`)
+- Hace que las habilidades estén disponibles en opencode
 - Crea **enlaces simbólicos** por defecto (ideal para mantener las habilidades actualizadas al hacer `git pull`)
 
 ### Opciones de instalación
@@ -45,28 +43,32 @@ Ventaja: las habilidades son independientes del repositorio original.
 
 ---
 
-## Habilidades Externas (Supabase y Firebase)
+## Routing vs Availability
 
-Las habilidades de **Supabase** y **Firebase** provienen de las habilidades oficiales creadas por las respectivas plataformas. En este repositorio se integran para usarlas bajo el flujo de **Skills.sh**. Residen en una carpeta externa (por defecto `~/.agents/skills/`). El bootstrap las procesa automáticamente:
+Este repositorio distingue tres conceptos que a menudo se confunden:
 
-```bash
-# El bootstrap toma por defecto ~/.agents/skills como fuente externa
-bash scripts/bootstrap.sh
-```
+| Concepto | Qué hace | Afecta detección en opencode |
+|----------|----------|-------------------------------|
+| **Routing lógico** (`.atl/skill-registry.md`) | Define **cuándo activar** cada skill según contexto y fase del proyecto | ❌ No |
+| **Bootstrap** (`scripts/bootstrap.sh`) | Instala skills en `~/.config/opencode/skills` vía enlaces simbólicos o copia | ✅ Sí |
+| **Instalación real** (`~/.config/opencode/skills/`) | Hace que opencode detecte y cargue la skill | ✅ Sí |
 
-### Origen de las habilidades oficiales
+### Skill State Model
 
-| Plataforma | Habilidad | Origen Oficial |
-|------------|-----------|----------------|
-| **Supabase** | `supabase`, `supabase-postgres-best-practices` | Habilidades oficiales de Supabase adaptadas para el flujo de Skills.sh |
-| **Firebase** | `firebase-*` (10 habilidades) | Habilidades oficiales de Firebase adaptadas para el flujo de Skills.sh |
+El registry clasifica cada skill con un estado que indica su disponibilidad real:
 
-### Rutas configurables
+- **repo-local**: La skill vive en este repositorio y el bootstrap la instala por defecto.
+- **external-bootstrappable**: La skill existe en `${AGENTS_DIR}` (por defecto `$HOME/.agents/skills`). El bootstrap puede enlazarla si el directorio externo está configurado.
+- **logical-only**: Regla de routing o candidato sin instalación garantizada. opencode no la cargará sin pasos manuales adicionales.
 
-| Variable | Valor por defecto | Propósito |
-|----------|-------------------|-----------|
-| `OPENCODE_SKILLS_DIR` | `~/.config/opencode/skills` | Dónde se instalan las habilidades |
-| `EXTERNAL_SKILLS_DIR` | `~/.agents/skills` | Fuente de habilidades externas |
+### ¿Por qué importa?
+
+Si el registry dice «activa `supabase` tras stack confirmado», eso es solo **routing lógico** para el orquestador. Para que opencode realmente use esa skill:
+
+1. La skill debe estar en `~/.config/opencode/skills/` (vía bootstrap o instalación manual)
+2. opencode debe estar reiniciado para refrescar la lista de skills
+
+Sin instalación física, el routing falla silenciosamente: el orquestador pedirá la skill pero opencode no la tendrá disponible. Consulta el [skill-registry](../.atl/skill-registry.md) para ver el estado actual de cada skill.
 
 ---
 
@@ -108,66 +110,9 @@ Si vas a usar **opencode en Windows**, la recomendación es correrlo bajo **WSL2
 
 ---
 
-## Enrutamiento de Habilidades por Stack
-
-Este repositorio usa un registro interno de habilidades para definir **orquestación lógica** (qué habilidad activar según el contexto), pero **no instala habilidades automáticamente**.
-
-### Cuándo se activa cada habilidad de Supabase
-
-| Habilidad | Cuándo se activa | Requiere stack confirmado |
-|-----------|------------------|---------------------------|
-| `supabase` | Tras decidir Supabase en `tech-feasibility`; fases de diseño/implementación | ✅ Sí |
-| `supabase-postgres-best-practices` | En fases de diseño/apply con trabajo SQL, RLS, migrations o esquema Postgres | ✅ Sí + contexto técnico |
-| `skill-creator` | Solo referencia documental; NO participa en routing normal | ❌ No |
-
-### Cuándo se activa cada habilidad de Firebase
-
-| Habilidad | Cuándo se activa | Requiere stack confirmado |
-|-----------|------------------|---------------------------|
-| `firebase-basics` | Tras decidir Firebase en `tech-feasibility` o setup de proyecto Firebase | ✅ Sí |
-| `firebase-auth-basics` | Con trabajo específico de Auth/sign-in/providers/tokens | ✅ Sí + contexto técnico |
-| `firebase-firestore-standard` | Con trabajo de Firestore Standard (queries, índices, SDK, reglas) | ✅ Sí + contexto técnico |
-| `firebase-firestore-enterprise-native-mode` | SOLO si Enterprise Native Mode está explícito | ✅ Sí + confirmación Enterprise |
-| `firebase-hosting-basics` | Para hosting clásico estático/SPA sin SSR | ✅ Sí + contexto de hosting |
-| `firebase-app-hosting-basics` | Para Next.js/Angular/SSR/App Hosting explícito | ✅ Sí + contexto de SSR/App |
-| `firebase-security-rules-auditor` | Para revisar/endurecer Security Rules | ✅ Sí + reglas concretas |
-| `firebase-data-connect` | Para Data Connect/SQL Connect/GraphQL/Postgres | ✅ Sí + contexto SQL/GraphQL |
-| `firebase-ai-logic-basics` | Para Firebase AI Logic/Gemini desde cliente | ✅ Sí + contexto de IA |
-
-> **Importante**: No activar habilidades Firebase solo por mencionar Firebase. Cada habilidad requiere contexto técnico específico o confirmación de stack.
-
-### Separación: Pipeline vs Disponibilidad Real
-
-```
-Pipeline/Registry (lógico)  →  Define CUÁNDO activar habilidades
-         ↓
-Bootstrap/Scripts (físico)  →  Hace que opencode DETECTE las habilidades
-```
-
-- **Pipeline/Registry**: la orquestación interna decide cuándo activar una habilidad tras confirmar el stack en `tech-feasibility`
-- **Bootstrap**: `scripts/install-opencode-skills.sh` instala habilidades del repo a `~/.config/opencode/skills/`
-- **Brecha actual**: Las habilidades externas requieren bootstrap + reinicio de opencode para quedar disponibles
-
-### Candidatas Externas (Non-Routable)
-
-Las habilidades candidatas documentadas en el `.atl/skill-registry.md` bajo `## External Adaptation Gate` (como `agent-governance` o `agentic-eval`) **no son instalables ni enrutableables** en este release.
-
-- **Solo las carpetas físicas** que contienen un archivo `SKILL.md` y son procesadas por el `bootstrap` quedan disponibles para opencode.
-- Las entradas en el registry bajo `## External Adaptation Gate` son **lógicas únicamente** y no activan routing ni instalación.
-- Para que una candidata sea instalable, debe cumplir con los criterios de entrada futura (tener un `SKILL.md` nativo, scope único, etc.) y migrar a `## User Skills` en el registry.
-
-#### Ownership Deny-List (reiteración mínima)
-Consulte `.atl/skill-registry.md` → `## External Adaptation Gate` → `### Ownership Deny-List` para el detalle oficial. En resumen:
-- `agent-governance` **no compite** con `repo-bootstrap`, `branch-pr`, `issue-creation` (ownership fuera de alcance).
-- `agentic-eval` **no compite** con `sdd-verify` (ownership fuera de alcance).
-
-#### Nota de alcance (isolation disclaimer)
-El cambio `adapt-awesome-copilot-skills-to-our-flow` modifica **únicamente** `.atl/skill-registry.md`, `README.md` y `docs/installation.md`. Cualquier otro diff presente en la rama (por ejemplo, `.github/workflows/release-please.yml`) pertenece a cambios independientes y **no forma parte del scope** de esta adaptación.
-
----
-
 ## Referencias
 
-- [Gentle AI Repository](https://github.com/Gentleman-Programming/gentle-ai) — Contexto del stack y mejor experiencia de uso
-- [docs/engram.md](engram.md) — Diferencia entre memoria persistente, bootstrap y skill-registry
-- [docs/sdd.md](sdd.md) — Desarrollo Guiado por Especificaciones (SDD) y sdd-orchestrator
+- [README principal](../README.md) — Qué es el repositorio, instalación rápida, flujo recomendado
+- [Contexto Gentle AI](gentle-ai.md) — Stack Gentle AI y relación con este repo
+- [Memoria Persistente (Engram)](engram.md) — Diferencia entre Engram, bootstrap y skill-registry
+- [Desarrollo Estructurado (SDD)](sdd.md) — SDD y sdd-orchestrator

--- a/product-discovery/SKILL.md
+++ b/product-discovery/SKILL.md
@@ -318,7 +318,7 @@ Esta skill está suficientemente bien resuelta cuando ya existe:
 
 ```markdown
 # [Nombre del Producto] — Discovery Report
-**Generado por:** product-discovery skill v2.0
+**Generado por:** product-discovery skill v3.0
 **Fecha:** [fecha]
 
 ## 1. Tipo de proyecto

--- a/tech-feasibility/SKILL.md
+++ b/tech-feasibility/SKILL.md
@@ -164,9 +164,7 @@ Solo puedes recomendar stack si ya sabes:
 3. ¿El equipo puede operar infraestructura propia?
 4. ¿El producto necesita salir rápido con bajo costo operativo?
 
-> **⚠️ Nota de disponibilidad de skills**: Si el stack elegido es Supabase, las skills `supabase` y `supabase-postgres-best-practices` residen en `/home/kkaps/.agents/skills/` y el bootstrap ya las procesa por defecto. `EXTERNAL_SKILLS_DIR` solo sirve si quieres cambiar la fuente externa. El pipeline define orquestación lógica (cuándo activar), no disponibilidad real.
->
-> **⚠️ Nota de disponibilidad de skills (Firebase)**: Si el stack elegido es Firebase, las skills de Firebase residen en `/home/kkaps/.agents/skills/` y el bootstrap ya las procesa por defecto. `EXTERNAL_SKILLS_DIR` solo sirve si quieres cambiar la fuente externa. El registry define orquestación lógica (cuándo activar), no garantiza disponibilidad real.
+> **⚠️ Disponibilidad de skills externas**: Para cualquier skill externa (Supabase, Firebase, Genkit), consulta el [skill-registry](../.atl/skill-registry.md) para ver el estado real de disponibilidad (repo-local, external-bootstrappable, logical-only). El bootstrap las procesa desde `${AGENTS_DIR}` (por defecto `$HOME/.agents/skills`). El pipeline y el registry definen orquestación lógica (cuándo activar), no disponibilidad real. Sin instalación física en `~/.config/opencode/skills`, opencode no detectará estas skills.
 
 ### Datos e infraestructura
 
@@ -328,13 +326,13 @@ Cuando el stack elegido sea **Supabase**, se activarán las siguientes skills en
 - **Cuándo activar**: Solo después de confirmar Supabase como backend en esta fase (`tech-feasibility`).
 - **Qué incluye**: Integración general (auth, realtime, storage, database).
 - **Fase de activación**: `sdd-design`, `sdd-apply`, desarrollo.
-- **⚠️ Advertencia de disponibilidad**: Esta skill reside en `/home/kkaps/.agents/skills/supabase/` y requiere instalación manual o script específico para estar disponible en `~/.config/opencode/skills`. Si no está instalada, el pipeline documenta la brecha pero no promete autoactivación real.
+- **⚠️ Disponibilidad**: external-bootstrappable vía `${AGENTS_DIR}/supabase/`. Requiere bootstrap (`bash scripts/bootstrap.sh`) o instalación manual. Sin instalación física en `~/.config/opencode/skills`, el routing es solo lógico.
 
 ### `supabase-postgres-best-practices`
 - **Cuándo activar**: En fases de diseño (`sdd-design`) o implementación (`sdd-apply`) cuando el trabajo entre en contexto SQL, RLS, migrations, performance o esquema Postgres.
 - **Qué incluye**: Mejores prácticas de PostgreSQL, políticas RLS, índices, optimización de consultas.
 - **NO activar**: Solo por haber elegido Supabase; debe haber trabajo técnico específico de base de datos.
-- **⚠️ Advertencia de disponibilidad**: Reside en `/home/kkaps/.agents/skills/supabase-postgres-best-practices/`. Requiere el mismo paso de instalación que `supabase`.
+- **⚠️ Disponibilidad**: external-bootstrappable vía `${AGENTS_DIR}/supabase-postgres-best-practices/`. Misma dependencia que `supabase`.
 
 ### Propagación de señal
 Al confirmar Supabase, la señal debe pasar a fases siguientes (`project-init` → `sdd-design` → `sdd-apply`) para que el orquestador active las skills correspondientes en su momento, según el contexto técnico específico.
@@ -349,7 +347,7 @@ Cuando el stack elegido sea **Firebase**, se activarán las siguientes skills en
 - **Cuándo activar**: Solo después de confirmar Firebase como backend/BaaS en esta fase (`tech-feasibility`) o cuando la conversación pida inicialización/CLI/proyecto Firebase.
 - **Qué incluye**: Configuración general (auth, proyectos, CLI, reglas base).
 - **Fase de activación**: `sdd-design`, `sdd-apply`, desarrollo.
-- **⚠️ Advertencia de disponibilidad**: Esta skill reside en `/home/kkaps/.agents/skills/firebase-basics/` y requiere instalación manual o script específico para estar disponible en `~/.config/opencode/skills`. Si no está instalada, el pipeline documenta la brecha pero no promete autoactivación real.
+- **⚠️ Disponibilidad**: external-bootstrappable vía `${AGENTS_DIR}/firebase-basics/`. Requiere bootstrap (`bash scripts/bootstrap.sh`) o instalación manual. Sin instalación física en `~/.config/opencode/skills`, el routing es solo lógico.
 
 ### `firebase-auth-basics`
 - **Cuándo activar**: En fases de diseño/implementación cuando el trabajo sea específico de Auth (sign-in, providers, tokens, reglas con `request.auth`).
@@ -394,10 +392,28 @@ Cuando el stack elegido sea **Firebase**, se activarán las siguientes skills en
 ### `developing-genkit-js`
 - **Cuándo activar**: Cuando haya trabajo Genkit en JS/TS (Node.js/TypeScript).
 - **Qué incluye**: Desarrollo de features con Genkit en JavaScript/TypeScript.
-- **NO activar**: Para otros lenguajes; usar `developing-genkit-dart` (Flutter), `developing-genkit-go` (Go), o `developing-genkit-python` (Python) según stack real.
+- **NO activar**: Para otros lenguajes; usar la skill específica según la matriz Genkit multi-lenguaje (ver sección más abajo).
+- **⚠️ Disponibilidad**: external-bootstrappable vía `${AGENTS_DIR}/developing-genkit-js/`. Ver [skill-registry](../.atl/skill-registry.md) para la matriz completa.
 
 ### Propagación de señal (Firebase)
 Al confirmar Firebase, la señal debe pasar a fases siguientes (`project-init` → `sdd-design` → `sdd-apply`) para que el orquestador active las skills correspondientes en su momento, según el contexto técnico específico y el registry (`.atl/skill-registry.md`).
+
+---
+
+## Genkit (independiente del stack)
+
+Cuando el producto requiera features de IA generativa con Genkit, la activación debe hacerse por lenguaje. Genkit no está atado a un stack específico (puede coexistir con Supabase, Firebase o backend propio).
+
+| Skill | Trigger | Disponibilidad |
+|-------|---------|----------------|
+| `developing-genkit-js` | Trabajo Genkit en JS/TS (Node.js/TypeScript) | external-bootstrappable |
+| `developing-genkit-dart` | Trabajo Genkit en Dart/Flutter | external-bootstrappable |
+| `developing-genkit-go` | Trabajo Genkit en Go | external-bootstrappable |
+| `developing-genkit-python` | Trabajo Genkit en Python | external-bootstrappable |
+
+> **Routing lógico**: La matriz completa con triggers detallados y reglas anti-solape está en el [skill-registry](../.atl/skill-registry.md). Todas las skills Genkit son external-bootstrappable: requieren bootstrap (`bash scripts/bootstrap.sh`) o instalación manual desde `${AGENTS_DIR}` para activación real en opencode.
+>
+> Genkit NO se activa por defecto al elegir un stack. Requiere que el trabajo entre explícitamente en contexto de IA generativa con el lenguaje correspondiente.
 
 ---
 


### PR DESCRIPTION
Closes #45

## Summary
- Stabilizes skill governance by making `repo-bootstrap` the source of truth and documenting solo-dev/team approval rules consistently.
- Aligns product-discovery output versioning to v3.0 and publishes the portable skill registry contract.
- Clarifies routing vs availability for external skills and documents Genkit language-specific routing.

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Changes
| File | Change |
|------|--------|
| `.atl/skill-registry.md` | Adds portable registry contract, state model, unified external skill availability disclaimer, and Genkit JS/Dart/Go/Python routing. |
| `product-discovery/SKILL.md` | Corrects output template version from v2.0 to v3.0. |
| `dev-skills/repo-bootstrap/SKILL.md` | Declares governance source of truth and solo-dev/team modes. |
| `docs/governance.md` | Mirrors governance modes and bifurcates solo-dev/team PR workflow. |
| `docs/installation.md` | Explains routing vs bootstrap vs real installation. |
| `docs/engram.md` | Aligns external skill state model with registry. |
| `tech-feasibility/SKILL.md` | Replaces absolute external skill paths and adds Genkit language matrix. |
| `README.md`, `docs/README.md` | Keeps public docs concise and aligned with the stabilized documentation model. |

## Test Plan
- [x] SDD verify passed with warnings only: `sdd/stabilize-skills-governance-routing/verify-report`
- [x] Verified no `v2.0` references remain in the repo.
- [x] Verified governance solo-dev/team rules are consistent across `repo-bootstrap` and `docs/governance.md`.
- [x] Verified registry uses portable external skill references and Genkit language routing.
- [ ] Local shellcheck: not run because `shellcheck` is not installed in this environment; no scripts were modified.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [ ] Ran shellcheck on modified scripts (not applicable: no scripts modified; local shellcheck unavailable)
- [x] Skills tested/verified through SDD verify
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers